### PR TITLE
Use https instead of ssh for the-forge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/microsoft/vcpkg.git
 [submodule "external/The-Forge"]
 	path = external/The-Forge
-	url = git@github.com:OSS-Cosmic/The-Forge.git
+	url = https://github.com/OSS-Cosmic/The-Forge.git


### PR DESCRIPTION
Currently, the-forge is set as a submodule with ssh, this changes to use https instead.

I ran into an issue with this with attempting to create a github action based on a docker container that doesn't have ssh. Because of that the submodule init failed. Changing to https does not seem to cause any issues.