### PR TITLE
feat: simplify material type scheme

### DIFF
--- a/HPL2/include/graphics/Enum.h
+++ b/HPL2/include/graphics/Enum.h
@@ -5,16 +5,6 @@
 
 namespace hpl
 {
-    namespace material {
-        enum MaterialID: uint8_t {
-            SolidDiffuse,
-            Translucent,
-            Water,
-            Decal,
-            MaterialIDCount
-        };
-    }
-
 
     enum class WrapMode : uint8_t {
         None,
@@ -45,23 +35,6 @@ namespace hpl
         RGB = R | G | B,
         RGBA = RGB | A,
     };
-
-    // enum class RenderableType: uint8_t {
-    //     Renderable_Z,
-	// 	Renderable_Diffuse,
-	// 	Renderable_Translucent,
-	// 	Renderable_Decal,
-	// 	Renderable_Illumination,
-	// 	Renderable_LastEnum
-    // };
-
-    // enum class RenderableBitFlag: uint8_t {
-    //     Renderable_Z = 1 << static_cast<uint8_t>(RenderableType::Renderable_Z),
-    //     Renderable_Diffuse = 1 << static_cast<uint8_t>(RenderableType::Renderable_Diffuse),
-    //     Renderable_Translucent = 1 << static_cast<uint8_t>(RenderableType::Renderable_Translucent),
-    //     Renderable_Decal = 1 << static_cast<uint8_t>(RenderableType::Renderable_Decal),
-    //     Renderable_Illumination = 1 << static_cast<uint8_t>(RenderableType::Renderable_Illumination),
-    // };
 
     enum class ClearOp: uint32_t {
         None = 0,

--- a/HPL2/include/graphics/Material.h
+++ b/HPL2/include/graphics/Material.h
@@ -39,11 +39,11 @@ namespace hpl {
 	class iMaterialType;
 	class cResourceVarsObject;
 
-
-    struct MaterialDecal {
+    struct MaterialDecal final {
         eMaterialBlendMode m_blend;
     };
-    struct MaterialDiffuseSolid {
+
+    struct MaterialDiffuseSolid final {
         float m_heightMapScale;
         float m_heightMapBias;
         float m_frenselBias;
@@ -51,7 +51,7 @@ namespace hpl {
         bool m_alphaDissolveFilter;
     };
 
-    struct MaterialTranslucent {
+    struct MaterialTranslucent final {
         eMaterialBlendMode m_blend;
 
         bool m_isAffectedByLightLevel;
@@ -68,7 +68,7 @@ namespace hpl {
     };
 
     // always has refraction if enabled
-    struct MaterialWater {
+    struct MaterialWater final {
         bool m_hasReflection;
         bool m_isLargeSurface;
         bool m_worldReflectionOcclusionTest; //DEPRECATED
@@ -102,13 +102,7 @@ namespace hpl {
         };
     };
 
-	class iMaterialVars
-	{
-	public:
-		virtual ~iMaterialVars(){}
-	};
-
-	class cMaterialUvAnimation
+	class cMaterialUvAnimation final
 	{
 	public:
 		cMaterialUvAnimation(eMaterialUvAnimation aType, float afSpeed, float afAmp, eMaterialAnimationAxis aAxis) :
@@ -173,10 +167,9 @@ namespace hpl {
 			MaterialMeta { MaterialID::Decal,"decal", std::span(DecalMaterialUsedTextures)}
 		};
 
-		cMaterial(const tString& asName, const tWString& asFullPath, cGraphics *apGraphics, cResources *apResources);
+		cMaterial(const tString& asName, const tWString& asFullPath, cResources *apResources);
 		virtual ~cMaterial();
 
-		void Compile();
 		void SetImage(eMaterialTexture aType, iResourceBase *apTexture);
 		Image* GetImage(eMaterialTexture aType);
 		const Image* GetImage(eMaterialTexture aType) const;
@@ -240,22 +233,21 @@ namespace hpl {
         eTextureWrap m_textureWrap = eTextureWrap::eTextureWrap_Clamp;
         eTextureFilter m_textureFilter = eTextureFilter::eTextureFilter_Nearest;
 
-		cGraphics *mpGraphics;
 		cResources *mpResources;
 	    MaterialDescriptor m_descriptor;
 		IndexPoolHandle m_handle;
 
 		std::array<ImageResourceWrapper, eMaterialTexture_LastEnum> m_image = {ImageResourceWrapper()};
 		std::vector<cMaterialUvAnimation> mvUvAnimations;
-		cMatrixf m_mtxUV;
+		cMatrixf m_mtxUV = cMatrixf::Identity;
 		tString msPhysicsMaterial;
 
 		uint32_t m_generation = 0; // used to check if the material has changed since last frame
-		float mfAnimTime;
+		float mfAnimTime = 0;
 		int mlRenderFrameCount = -1;
 
 		bool mbAutoDestroyTextures = true;
-		bool mbDepthTest;
+		bool mbDepthTest = true;
 
 	};
 

--- a/HPL2/include/graphics/Material.h
+++ b/HPL2/include/graphics/Material.h
@@ -71,19 +71,26 @@ namespace hpl {
     struct MaterialWater {
         bool m_hasReflection;
         bool m_isLargeSurface;
-        float m_maxReflectionDistance;
+        bool m_worldReflectionOcclusionTest; //DEPRECATED
 
         float m_refractionScale;
         float m_frenselBias;
-        float mfFrenselPow;
-        float mfReflectionFadeStart;
-        float mfReflectionFadeEnd;
-        float mfWaveSpeed;
-        float mfWaveAmplitude;
-        float mfWaveFreq;
+        float m_frenselPow;
+        float m_reflectionFadeStart;
+        float m_reflectionFadeEnd;
+        float m_waveSpeed;
+        float m_waveAmplitude;
+        float m_waveFreq;
     };
 
-    enum class MaterialID : uint8_t { Unknown = 0, SolidDiffuse, Translucent, Water, Decal, MaterialIDCount };
+    enum class MaterialID : uint8_t {
+        Unknown = 0,
+        SolidDiffuse,
+        Translucent,
+        Water,
+        Decal,
+        MaterialIDCount
+    };
 
     struct MaterialDescriptor final {
         MaterialID m_id = MaterialID::Unknown;
@@ -95,15 +102,11 @@ namespace hpl {
         };
     };
 
-
 	class iMaterialVars
 	{
 	public:
 		virtual ~iMaterialVars(){}
 	};
-
-
-	//---------------------------------------------------
 
 	class cMaterialUvAnimation
 	{
@@ -124,6 +127,11 @@ namespace hpl {
 	friend class iMaterialType;
 	public:
 		static constexpr uint32_t MaxMaterialID = 2048;
+        static constexpr bool IsTranslucent(const MaterialID id) {
+            return id == MaterialID::Water ||
+                id == MaterialID::Translucent ||
+                id == MaterialID::Decal;
+        }
 
         enum TextureAntistropy {
             Antistropy_None = 0,
@@ -131,70 +139,6 @@ namespace hpl {
             Antistropy_16 = 2,
             Antistropy_Count = 3
         };
-
-		struct MaterialCommonBlock {
-			uint32_t m_materialConfig;
-		};
-
-		struct MaterialSolidUniformBlock {
-			uint32_t m_materialConfig;
-			float m_heightMapScale;
-			float m_heightMapBias;
-			float m_frenselBias;
-
-			float m_frenselPow;
-			uint32_t m_pad0;
-			uint32_t m_pad1;
-			uint32_t m_pad2;
-		};
-
-		struct MaterialTranslucentUniformBlock {
-			uint32_t m_materialConfig;
-			float mfRefractionScale;
-			float mfFrenselBias;
-			float mfFrenselPow;
-
-			float mfRimLightMul;
-			float mfRimLightPow;
-			uint32_t m_pad0;
-			uint32_t m_pad1;
-		};
-
-		struct MaterialWaterUniformBlock {
-			uint32_t m_materialConfig;
-			float mfRefractionScale;
-			float mfFrenselBias;
-			float mfFrenselPow;
-
-			float mfReflectionFadeStart;
-			float mfReflectionFadeEnd;
-			float mfWaveSpeed;
-			float mfWaveAmplitude;
-
-			float mfWaveFreq;
-			uint32_t m_pad0;
-			uint32_t m_pad1;
-			uint32_t m_pad2;
-		};
-
-
-		struct MaterialType {
-			//
-			bool m_affectByLightLevel = false;
-
-			MaterialID m_id;
-			IndexPoolHandle m_handle;
-			// solid
-			bool m_alphaDissolveFilter = false;
-			bool m_refractionNormals = false;
-			union MaterialData {
-				MaterialData() {}
-				MaterialCommonBlock m_common;
-				MaterialSolidUniformBlock m_solid;
-				MaterialTranslucentUniformBlock m_translucentUniformBlock;
-				MaterialWaterUniformBlock m_waterUniformBlock;
-			} m_data;
-		};
 
 		struct MaterialUserVariable {
 			const char* m_name;
@@ -205,12 +149,9 @@ namespace hpl {
 		struct MaterialMeta {
 			MaterialID m_id;
 			const char* m_name;
-			bool m_isDecal ;
-			bool m_isTranslucent;
 			std::span<const eMaterialTexture> m_usedTextures;
 			std::span<const MaterialUserVariable> m_userVariables;
 		};
-
 
 		static constexpr eMaterialTexture SolidMaterialUsedTextures[] = {
 			eMaterialTexture_Diffuse ,eMaterialTexture_NMap ,eMaterialTexture_Alpha ,eMaterialTexture_Specular ,eMaterialTexture_Height ,eMaterialTexture_Illumination ,eMaterialTexture_DissolveAlpha ,eMaterialTexture_CubeMap ,eMaterialTexture_CubeMapAlpha
@@ -226,70 +167,24 @@ namespace hpl {
 		};
 
 		static constexpr const std::array MaterialMetaTable {
-			MaterialMeta { MaterialID::SolidDiffuse,"soliddiffuse", false, false, std::span(SolidMaterialUsedTextures)},
-			MaterialMeta { MaterialID::Translucent,"translucent", false, true, std::span(TranslucentMaterialUsedTextures)},
-			MaterialMeta { MaterialID::Water,"water", false, true, std::span(WaterMaterialUsedTextures)},
-			MaterialMeta { MaterialID::Decal,"decal", true, true, std::span(DecalMaterialUsedTextures)}
+			MaterialMeta { MaterialID::SolidDiffuse,"soliddiffuse", std::span(SolidMaterialUsedTextures)},
+			MaterialMeta { MaterialID::Translucent,"translucent", std::span(TranslucentMaterialUsedTextures)},
+			MaterialMeta { MaterialID::Water,"water", std::span(WaterMaterialUsedTextures)},
+			MaterialMeta { MaterialID::Decal,"decal", std::span(DecalMaterialUsedTextures)}
 		};
 
-		cMaterial(const tString& asName, const tWString& asFullPath, cGraphics *apGraphics, cResources *apResources, iMaterialType *apType);
+		cMaterial(const tString& asName, const tWString& asFullPath, cGraphics *apGraphics, cResources *apResources);
 		virtual ~cMaterial();
-
-		void SetType(iMaterialType* apType);
-		iMaterialType * GetType(){ return mpType; }
 
 		void Compile();
 		void SetImage(eMaterialTexture aType, iResourceBase *apTexture);
 		Image* GetImage(eMaterialTexture aType);
 		const Image* GetImage(eMaterialTexture aType) const;
 
-	    void SetVars(iMaterialVars *apVars){ mpVars = apVars;}
-		iMaterialVars* GetVars(){ return mpVars;}
-		cResourceVarsObject* GetVarsObject();
-		void LoadVariablesFromVarsObject(cResourceVarsObject* apVarsObject);
-
-		void SetAutoDestroyTextures(bool abX) {
-			mbAutoDestroyTextures = abX;
-			for(auto& image: m_image) {
-				image.SetAutoDestroyResource(abX);
-			}
-		}
-
+		void SetAutoDestroyTextures(bool abX);
 		void SetTextureAnisotropy(float afx);
-		void SetBlendMode(eMaterialBlendMode aBlendMode);
-		void SetAlphaMode(eMaterialAlphaMode aAlphaMode);
-		void SetDepthTest(bool abDepthTest);
 
-		bool HasRefraction(){ return mbHasRefraction; }
-		bool HasRefractionNormals(){ return mbHasRefractionNormals; }
-		bool IsRefractionEdgeCheck(){ return mbUseRefractionEdgeCheck;}
-		void SetHasRefraction(bool abX){ mbHasRefraction = abX; }
-		void SetHasRefractionNormals(bool abX){ mbHasRefractionNormals = abX; }
-		void SetIsAffectedByLightLevel(bool abX){ mbIsAffectedByLightLevel = abX;}
-		bool IsAffectedByLightLevel(){ return mbIsAffectedByLightLevel;}
-		void SetUseRefractionEdgeCheck(bool abX){ mbUseRefractionEdgeCheck = abX;}
-
-		bool HasWorldReflection(){ return mbHasWorldReflection; }
-		void SetHasWorldReflection(bool abX){ mbHasWorldReflection = abX; }
-		void  SetWorldReflectionOcclusionTest(bool abX){ mbWorldReflectionOcclusionTest=abX;}
-		void SetMaxReflectionDistance(float afX){ mfMaxReflectionDistance = afX;}
-		bool  GetWorldReflectionOcclusionTest(){ return mbWorldReflectionOcclusionTest;}
-		float GetMaxReflectionDistance(){ return mfMaxReflectionDistance;}
-
-		//void SetHasTranslucentIllumination(bool abX){ mbHasTranslucentIllumination = abX;}
-		//bool HasTranslucentIllumination(){ return mbHasTranslucentIllumination;}
-
-		void SetLargeTransperantSurface(bool abX){ mbLargeTransperantSurface = abX;}
-		bool GetLargeTransperantSurface(){ return mbLargeTransperantSurface;}
-
-		bool GetUseAlphaDissolveFilter(){ return mbUseAlphaDissolveFilter;}
-		void SetUseAlphaDissolveFilter(bool abX){ mbUseAlphaDissolveFilter = abX;}
-
-		void SetAffectedByFog(bool abX){ mbAffectedByFog = abX;}
-		bool GetAffectedByFog(){ return mbAffectedByFog;}
-
-		inline eMaterialBlendMode GetBlendMode() const { return mBlendMode; }
-		inline eMaterialAlphaMode GetAlphaMode() const { return mAlphaMode; }
+	    void SetDepthTest(bool abDepthTest);
 		inline bool GetDepthTest() const { return mbDepthTest; }
 
 		void SetPhysicsMaterial(const tString & asPhysicsMaterial){ msPhysicsMaterial = asPhysicsMaterial;}
@@ -301,48 +196,28 @@ namespace hpl {
         inline TextureAntistropy GetTextureAntistropy() const { return m_antistropy; }
         inline eTextureWrap GetTextureWrap() const { return m_textureWrap; }
 
-        inline void setTextureFilter(eTextureFilter filter) {
-            m_textureFilter = filter;
-            Dirty();
-        }
-        inline void setTextureWrap(eTextureWrap wrap) {
-            m_textureWrap = wrap;
-            Dirty();
-        }
+        void setTextureFilter(eTextureFilter filter);
+        void setTextureWrap(eTextureWrap wrap);
 		inline int GetRenderFrameCount() const { return mlRenderFrameCount;}
 		inline void SetRenderFrameCount(const int alCount) { mlRenderFrameCount = alCount;}
-
-		inline bool GetHasSpecificSettings(eMaterialRenderMode aMode) const{ return mbHasSpecificSettings[aMode];}
-		void SetHasSpecificSettings(eMaterialRenderMode aMode,bool abX){ mbHasSpecificSettings[aMode] = abX;}
-
-		inline bool HasObjectSpecificsSettings(eMaterialRenderMode aMode)const { return  mbHasObjectSpecificsSettings[aMode];}
-		void SetHasObjectSpecificsSettings(eMaterialRenderMode aMode,bool abX){ mbHasObjectSpecificsSettings[aMode] = abX;}
 
 		//Animation
 		void AddUvAnimation(eMaterialUvAnimation aType, float afSpeed, float afAmp, eMaterialAnimationAxis aAxis);
 		int GetUvAnimationNum(){ return (int)mvUvAnimations.size();}
 		cMaterialUvAnimation *GetUvAnimation(int alIdx){ return &mvUvAnimations[alIdx]; }
-		inline bool HasUvAnimation()const { return mbHasUvAnimation; }
 		inline const cMatrixf& GetUvMatrix() const { return m_mtxUV;}
 		void ClearUvAnimations();
 
         // we want to build a derived state from the matera information
         // decouples the state managment to work on forward++ model
-        eMaterialBlendMode Desc_GetBlendMode() const;
-        eMaterialAlphaMode Desc_GetAlphaMode() const;
-        bool Desc_GetHasRefraction() const;
-        bool Desc_GetHasReflection() const;
-        bool Desc_GetHasWorldReflections() const;
-        bool Desc_GetIsAffectedByLight() const;
-        bool Desc_GetLargeTransperantSurface() const;
-        float Desc_maxReflectionDistance() const;
-
-		/**
-		 * This is used so that materials do not call type specific things after types have been destroyed!
-		 * Shall only be set by graphics!
-		 */
-		static void SetDestroyTypeSpecifics(bool abX){ mbDestroyTypeSpecifics = abX; }
-		static bool GetDestroyTypeSpecifics(){ return mbDestroyTypeSpecifics; }
+        eMaterialBlendMode GetBlendMode() const;
+        eMaterialAlphaMode GetAlphaMode() const;
+        bool HasRefraction() const;
+        bool HasReflection() const;
+        bool HasWorldReflection() const;
+        bool IsAffectedByLightLevel() const;
+        bool GetLargeTransperantSurface() const;
+        float GetMaxReflectionDistance() const;
 
 		bool Reload(){ return false;}
 		void Unload(){}
@@ -350,70 +225,38 @@ namespace hpl {
 
         inline void SetDescriptor(const MaterialDescriptor& desc) {
             m_descriptor = desc;
-            Dirty();
+            IncreaseGeneration();
         }
-        const MaterialDescriptor& Descriptor() const {
+        inline const MaterialDescriptor& Descriptor() const {
             return m_descriptor;
         }
-		inline MaterialType& type() { return m_info; }
 
-		inline uint32_t materialID() { return m_info.m_handle.get(); }
-		inline uint32_t Version() { return m_version; }
-	    inline void Dirty() { m_version++; }
+		inline uint32_t Index() { return m_handle.get(); }
+	    inline void SetHandle(IndexPoolHandle&& handle) { m_handle = std::move(handle); }
+		inline uint32_t Generation() { return m_generation; }
+	    inline void IncreaseGeneration() { m_generation++; }
     private:
-		void UpdateFlags();
-		void UpdateAnimations(float afTimeStep);
-		uint32_t m_version = 0; // used to check if the material has changed since last frame
-		MaterialType m_info;
         TextureAntistropy m_antistropy = Antistropy_None;
         eTextureWrap m_textureWrap = eTextureWrap::eTextureWrap_Clamp;
         eTextureFilter m_textureFilter = eTextureFilter::eTextureFilter_Nearest;
 
 		cGraphics *mpGraphics;
 		cResources *mpResources;
-		iMaterialType *mpType;
-		iMaterialVars *mpVars;
 	    MaterialDescriptor m_descriptor;
-
-		bool mbAutoDestroyTextures;
-		bool mbHasSpecificSettings[eMaterialRenderMode_LastEnum];
-		bool mbHasObjectSpecificsSettings[eMaterialRenderMode_LastEnum];
-
-		eMaterialBlendMode mBlendMode;
-		eMaterialAlphaMode mAlphaMode;
-		int mlRefractionTextureUnit;
-
-		int mlWorldReflectionTextureUnit;
-		float mfMaxReflectionDistance;
-
-		bool mbDepthTest;
-		bool mbHasRefraction;
-		bool mbHasRefractionNormals;
-		bool mbUseRefractionEdgeCheck;
-		bool mbHasWorldReflection;
-		bool mbWorldReflectionOcclusionTest;
-		//bool mbHasTranslucentIllumination = false;
-		bool mbLargeTransperantSurface;
-		bool mbAffectedByFog;
-		bool mbUseAlphaDissolveFilter;
-		bool mbHasUvAnimation;
-		bool mbIsAffectedByLightLevel;
+		IndexPoolHandle m_handle;
 
 		std::array<ImageResourceWrapper, eMaterialTexture_LastEnum> m_image = {ImageResourceWrapper()};
-
 		std::vector<cMaterialUvAnimation> mvUvAnimations;
 		cMatrixf m_mtxUV;
-
-		float mfAnimTime;
-
-		int mlRenderFrameCount;
-
 		tString msPhysicsMaterial;
 
-		static bool mbDestroyTypeSpecifics;
-		uint32_t m_stageDirtyBits = 0;
-	};
+		uint32_t m_generation = 0; // used to check if the material has changed since last frame
+		float mfAnimTime;
+		int mlRenderFrameCount = -1;
 
-	//---------------------------------------------------
+		bool mbAutoDestroyTextures = true;
+		bool mbDepthTest;
+
+	};
 
 };

--- a/HPL2/include/graphics/MaterialResource.h
+++ b/HPL2/include/graphics/MaterialResource.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "graphics/Material.h"
+#include <cstdint>
+
+namespace hpl {
+    class cMaterial;
+
+    namespace material {
+        enum TextureConfigFlags {
+            EnableDiffuse = 1 << 0,
+            EnableNormal = 1 << 1,
+            EnableSpecular = 1 << 2,
+            EnableAlpha = 1 << 3,
+            EnableHeight = 1 << 4,
+            EnableIllumination = 1 << 5,
+            EnableCubeMap = 1 << 6,
+            EnableDissolveAlpha = 1 << 7,
+            EnableCubeMapAlpha = 1 << 8,
+
+            // additional flags
+            IsHeightMapSingleChannel = 1 << 9,
+            IsAlphaSingleChannel = 1 << 10,
+
+            // Solid Diffuse
+            UseDissolveFilter = 1 << 14,
+
+            // Translucent
+            UseRefractionNormals = 1 << 14,
+            UseRefractionEdgeCheck = 1 << 15,
+        };
+
+        struct UniformMaterialBlock {
+            union {
+                struct {
+                    uint32_t m_materialConfig;
+                } m_common;
+                struct {
+                    uint32_t m_materialConfig;
+                    float m_heightMapScale;
+                    float m_heightMapBias;
+                    float m_frenselBias;
+
+                    float m_frenselPow;
+                    uint32_t m_pad0;
+                    uint32_t m_pad1;
+                    uint32_t m_pad2;
+                } m_solid;
+
+                struct {
+                    uint32_t m_materialConfig;
+                    float m_refractionScale;
+                    float m_frenselBias;
+                    float m_frenselPow;
+
+                    float mfRimLightMul;
+                    float mfRimLightPow;
+                    uint32_t m_pad0;
+                    uint32_t m_pad1;
+                } m_translucent;
+
+                struct {
+                    uint32_t m_materialConfig;
+                    float mfRefractionScale;
+                    float mfFrenselBias;
+                    float mfFrenselPow;
+
+                    float m_reflectionFadeStart;
+                    float m_reflectionFadeEnd;
+                    float m_waveSpeed;
+                    float mfWaveAmplitude;
+
+                    float mfWaveFreq;
+                    uint32_t m_pad0;
+                    uint32_t m_pad1;
+                    uint32_t m_pad2;
+                } m_water;
+            };
+            static UniformMaterialBlock CreateFromMaterial(cMaterial& material);
+            static uint32_t CreateMaterailConfigFlags(cMaterial& material);
+        };
+    } // namespace material
+} // namespace hpl

--- a/HPL2/include/graphics/MaterialType_BasicSolid.h
+++ b/HPL2/include/graphics/MaterialType_BasicSolid.h
@@ -29,18 +29,6 @@ namespace hpl {
 
     class iMaterialVars;
 
-    namespace material::solid {
-        enum DiffuseVariant : uint32_t {
-            Diffuse_None = 0,
-            Diffuse_NormalMap = 0x00001,
-            Diffuse_SpecularMap = 0x00002,
-            Diffuse_ParallaxMap = 0x00004,
-            Diffuse_EnvMap = 0x00008
-        };
-
-        enum ZVariant : uint32_t { Z_None = 0, Z_UseAlphaMap = 0x00001, Z_UseDissolveFilter = 0x00002, Z_UseDissolveAlphaMap = 0x00004 };
-    } // namespace material::solid
-
     class iMaterialType_SolidBase : public iMaterialType {
         HPL_RTTI_IMPL_CLASS(iMaterialType, iMaterialType_SolidBase, "{06ca56f9-381f-4b73-aaa3-3c951b8d6cad}")
     public:
@@ -65,39 +53,9 @@ namespace hpl {
         void LoadData();
         void DestroyData();
 
-        Image* m_dissolveImage = nullptr;
-
         static float mfVirtualPositionAddScale;
     };
 
-    class cMaterialType_SolidDiffuse_Vars : public iMaterialVars {
-    public:
-        std::array<SharedBuffer, ForgeRenderer::SwapChainLength> m_buffer;
-
-        cMaterialType_SolidDiffuse_Vars()
-            : mfHeightMapScale(0.05f)
-            , mfHeightMapBias(0.0f)
-            , mbAlphaDissolveFilter(false) {
-        }
-        ~cMaterialType_SolidDiffuse_Vars() {
-        }
-
-        struct MaterialBufferData {
-            struct {
-                mat4 m_uvMtx;
-                float alphaReject;
-                uint32_t textureConfig;
-            } m_z;
-        } m_vars;
-
-        uint32_t m_materialId = 0;
-
-        float mfHeightMapScale;
-        float mfHeightMapBias;
-        float mfFrenselBias;
-        float mfFrenselPow;
-        bool mbAlphaDissolveFilter;
-    };
 
     class cMaterialType_SolidDiffuse : public iMaterialType_SolidBase {
 		HPL_RTTI_IMPL_CLASS(iMaterialType_SolidBase, cMaterialType_SolidDiffuse, "{06904083-3217-48b9-bb27-772df4573557}")

--- a/HPL2/include/graphics/MaterialType_BasicTranslucent.h
+++ b/HPL2/include/graphics/MaterialType_BasicTranslucent.h
@@ -26,35 +26,7 @@
 namespace hpl
 {
 
-    class cMaterialType_Translucent_Vars : public iMaterialVars
-    {
-    public:
-        cMaterialType_Translucent_Vars()
-            : mbRefraction(false)
-            , mbRefractionEdgeCheck(true)
-            , mbRefractionNormals(false)
-            , mfRefractionScale(0.1f)
-            , mfFrenselBias(0.2f)
-            , mfFrenselPow(8.0f)
-        {
-        }
-        ~cMaterialType_Translucent_Vars()
-        {
-        }
-
-        bool mbRefraction;
-        bool mbRefractionEdgeCheck;
-        bool mbRefractionNormals;
-        float mfRefractionScale;
-        float mfFrenselBias;
-        float mfFrenselPow;
-        float mfRimLightMul;
-        float mfRimLightPow;
-        bool mbAffectedByLightLevel;
-    };
-
-    //--------------------------------------------------
-
+    //DEPRECATED
     class cMaterialType_Translucent : public iMaterialType
     {
         HPL_RTTI_IMPL_CLASS(iMaterialType, cMaterialType_Translucent, "{cc03a5ac-9137-4e94-ab6b-095a6c9f0085}")

--- a/HPL2/include/graphics/MaterialType_Decal.h
+++ b/HPL2/include/graphics/MaterialType_Decal.h
@@ -23,17 +23,7 @@
 
 namespace hpl {
 
-	//---------------------------------------------------
-	// Decal
-	//---------------------------------------------------
-
-	class cMaterialType_Decal_Vars : public iMaterialVars
-	{
-	public:
-		cMaterialType_Decal_Vars(){}
-		~cMaterialType_Decal_Vars(){}
-   	};
-
+    // DEPRECATED
 	class cMaterialType_Decal : public iMaterialType
 	{
 		HPL_RTTI_IMPL_CLASS(iMaterialType, cMaterialType_Decal, "{c0c72fe2-2cb7-4b77-a49b-65660b4dfe45}")

--- a/HPL2/include/graphics/MaterialType_Water.h
+++ b/HPL2/include/graphics/MaterialType_Water.h
@@ -23,38 +23,6 @@
 
 namespace hpl {
 
-
-  	namespace material::water
-    {
-		enum WaterVariant: uint32_t
-		{
-			None = 0,
-			UseReflection = 0x00001,
-			UseFog = 0x00002,
-			UseCubeMapReflection = 0x00004,
-			UseRefraction = 0x00008
-		};
-	}
-
-	class cMaterialType_Water_Vars : public iMaterialVars
-	{
-	public:
-		cMaterialType_Water_Vars() : mbHasReflection(true), mfRefractionScale(0.1f), mfFrenselBias(0.2f), mfFrenselPow(8.0f){}
-		~cMaterialType_Water_Vars(){}
-
-        bool mbHasReflection;
-		float mfRefractionScale;
-		float mfFrenselBias;
-		float mfFrenselPow;
-		float mfReflectionFadeStart;
-		float mfReflectionFadeEnd;
-		float mfWaveSpeed;
-		float mfWaveAmplitude;
-		float mfWaveFreq;
-	};
-
-	//-----------------------------------------------------
-
 	class cMaterialType_Water : public iMaterialType
 	{
 		HPL_RTTI_IMPL_CLASS(iMaterialType, cMaterialType_Decal, "{cc45d7fd-aa4e-4a99-92fa-dc0c8b65bdf3}")

--- a/HPL2/include/graphics/RendererDeferred.h
+++ b/HPL2/include/graphics/RendererDeferred.h
@@ -362,10 +362,7 @@ namespace hpl {
             bool abSendFrameBufferToPostEffects) override;
 
     private:
-        LegacyRenderTarget& resolveRenderTarget(std::array<LegacyRenderTarget, 2>& rt);
-        std::shared_ptr<Image>& resolveRenderImage(std::array<std::shared_ptr<Image>, 2>& img);
         iVertexBuffer* GetLightShape(iLight* apLight, eDeferredShapeQuality aQuality) const;
-
         struct PerObjectOption {
             std::optional<cMatrixf> m_modelMatrix = std::nullopt;
         };

--- a/HPL2/sources/graphics/Graphics.cpp
+++ b/HPL2/sources/graphics/Graphics.cpp
@@ -84,7 +84,6 @@ namespace hpl {
 			pType->DestroyData();
 		}
 		STLMapDeleteAll(m_mapMaterialTypes);
-		cMaterial::SetDestroyTypeSpecifics(false); //Material types are destroyed! Remaining materials may not call!
 
 		STLDeleteAll(mvPostEffectTypes);
 

--- a/HPL2/sources/graphics/Material.cpp
+++ b/HPL2/sources/graphics/Material.cpp
@@ -25,9 +25,9 @@
 #include "system/LowLevelSystem.h"
 #include "system/String.h"
 
+#include "resources/ImageManager.h"
 #include "resources/Resources.h"
 #include "resources/TextureManager.h"
-#include "resources/ImageManager.h"
 
 #include "graphics/MaterialType.h"
 #include "graphics/Renderable.h"
@@ -35,246 +35,135 @@
 #include "math/Math.h"
 #include <utility>
 
-
-
 #include "tinyimageformat_query.h"
 
 namespace hpl {
 
-	bool cMaterial::mbDestroyTypeSpecifics = true;
+    cMaterial::cMaterial(
+        const tString& asName, const tWString& asFullPath, cGraphics* apGraphics, cResources* apResources)
+        : iResourceBase(asName, asFullPath, 0) {
+        m_generation = rand();
+        m_descriptor.m_id = MaterialID::Unknown;
+        mpGraphics = apGraphics;
+        mpResources = apResources;
 
-	cMaterial::cMaterial(const tString& asName, const tWString& asFullPath, cGraphics *apGraphics, cResources *apResources, iMaterialType *apType)
-		: iResourceBase(asName, asFullPath, 0)
-	{
-        m_version = rand();
-		mpGraphics = apGraphics;
-		mpResources = apResources;
+        mfAnimTime = 0;
+        m_mtxUV = cMatrixf::Identity;
 
-		mpType = NULL;
-		mpVars = NULL;
-		SetType(apType);
-
-		mbAutoDestroyTextures = true;
-
-		mlRenderFrameCount = -1;
-
-		mbHasRefraction = false;
-		mlRefractionTextureUnit =0;
-		mbUseRefractionEdgeCheck = false;
-
-		mbHasWorldReflection = false;
-		mlWorldReflectionTextureUnit =0;
-		mbWorldReflectionOcclusionTest = true;
-		mfMaxReflectionDistance = 0;
-
-		//mbHasTranslucentIllumination = false; //If the material is translucent and also need an extra additive pass.
-
-		mbLargeTransperantSurface = false;
-
-		mbUseAlphaDissolveFilter = false;
-
-		mbAffectedByFog = true;
-
-		for(int i=0; i<eMaterialRenderMode_LastEnum; ++i)
-		{
-			mbHasSpecificSettings[i] = false;
-			mbHasObjectSpecificsSettings[i] = false;
-		}
-
-		mfAnimTime = 0;
-		m_mtxUV = cMatrixf::Identity;
-		mbHasUvAnimation = false;
-
-
-		///////////////////////
-		//Set up depending in type
-		if(mpType->IsTranslucent())
-		{
-			mBlendMode = eMaterialBlendMode_Add;
-		}
-		else
-		{
-			mBlendMode = eMaterialBlendMode_None;
-		}
-		mAlphaMode = eMaterialAlphaMode_Solid;
-		mbDepthTest = true;
-
-	}
-
-	//-----------------------------------------------------------------------
-
-	cMaterial::~cMaterial()
-	{
-		if(mpVars) {
-			hplDelete(mpVars);
-		}
-	}
-
-	void cMaterial::SetType(iMaterialType* apType)
-	{
-		if(mpType == apType) {
-			return;
-		}
-
-		mpType = apType;
-
-		if(mpVars) {
-			hplDelete(mpVars);
-		}
-		if(mpType) {
-			mpVars = mpType->CreateSpecificVariables();
-		}
-	}
-
-	//-----------------------------------------------------------------------
-
-	void cMaterial::Compile()
-	{
-		for(int i=0; i<eMaterialRenderMode_LastEnum; ++i)
-		{
-			mbHasSpecificSettings[i] = false;
-			mbHasObjectSpecificsSettings[i] = false;
-		}
-
-		mpType->CompileMaterialSpecifics(this);
-		UpdateFlags();
-	}
-
-    void cMaterial::SetTextureAnisotropy(float afx) {
-        if(afx >= 16.0f) {
-            m_antistropy = Antistropy_16;
-        } else if(afx >= 8.0f) {
-            m_antistropy = Antistropy_8;
-        } else {
-            m_antistropy = Antistropy_None ;
-        }
-        Dirty();
+        mbDepthTest = true;
     }
 
-    eMaterialBlendMode cMaterial::Desc_GetBlendMode() const {
+    //-----------------------------------------------------------------------
+
+    cMaterial::~cMaterial() {
+    }
+
+    void cMaterial::Compile() {
+    }
+
+    void cMaterial::SetTextureAnisotropy(float afx) {
+        if (afx >= 16.0f) {
+            m_antistropy = Antistropy_16;
+        } else if (afx >= 8.0f) {
+            m_antistropy = Antistropy_8;
+        } else {
+            m_antistropy = Antistropy_None;
+        }
+        IncreaseGeneration();
+    }
+
+    eMaterialBlendMode cMaterial::GetBlendMode() const {
         // for water we enforce a blend mode
-        switch(m_descriptor.m_id) {
-            case MaterialID::Translucent:
-                return m_descriptor.m_translucent.m_blend;
-            case MaterialID::Decal:
-                return m_descriptor.m_decal.m_blend;
-            default:
-                break;
+        switch (m_descriptor.m_id) {
+        case MaterialID::Translucent:
+            return m_descriptor.m_translucent.m_blend;
+        case MaterialID::Decal:
+            return m_descriptor.m_decal.m_blend;
+        default:
+            break;
         }
         ASSERT(false && "material type does not have a blend mode");
         return eMaterialBlendMode_LastEnum;
     }
-    eMaterialAlphaMode cMaterial::Desc_GetAlphaMode() const {
-           switch(m_descriptor.m_id) {
-                case MaterialID::SolidDiffuse:
-                    if(GetImage(eMaterialTexture_Alpha))  {
-                        return eMaterialAlphaMode_Trans;
-                    }
-                    break;
-                default:
-                    break;
-            }
-	        return eMaterialAlphaMode_Solid;
-    }
-    bool cMaterial::Desc_GetIsAffectedByLight() const {
+    eMaterialAlphaMode cMaterial::GetAlphaMode() const {
         switch (m_descriptor.m_id) {
-            case MaterialID::Translucent:
-                return m_descriptor.m_translucent.m_isAffectedByLightLevel;
-            default:
-                break;
+        case MaterialID::SolidDiffuse:
+            if (GetImage(eMaterialTexture_Alpha)) {
+                return eMaterialAlphaMode_Trans;
+            }
+            break;
+        default:
+            break;
+        }
+        return eMaterialAlphaMode_Solid;
+    }
+    bool cMaterial::IsAffectedByLightLevel() const {
+        switch (m_descriptor.m_id) {
+        case MaterialID::Translucent:
+            return m_descriptor.m_translucent.m_isAffectedByLightLevel;
+        default:
+            break;
         }
 
         return false;
     }
-    bool cMaterial::Desc_GetHasRefraction() const {
+    bool cMaterial::HasRefraction() const {
         switch (m_descriptor.m_id) {
-            case MaterialID::Translucent:
-                    return m_descriptor.m_translucent.m_hasRefraction;
-            case MaterialID::Water:
-                    return true;
-            default:
-                    break;
+        case MaterialID::Translucent:
+            return m_descriptor.m_translucent.m_hasRefraction;
+        case MaterialID::Water:
+            return true;
+        default:
+            break;
         }
         return false;
     }
-    bool cMaterial::Desc_GetHasReflection() const {
-       switch(m_descriptor.m_id) {
-            case MaterialID::Water:
-                return m_descriptor.m_water.m_hasReflection;
-            default:
-                break;
+    bool cMaterial::HasReflection() const {
+        switch (m_descriptor.m_id) {
+        case MaterialID::Water:
+            return m_descriptor.m_water.m_hasReflection;
+        default:
+            break;
         }
         return false;
     }
-    bool cMaterial::Desc_GetHasWorldReflections() const {
+    bool cMaterial::HasWorldReflection() const {
         return m_descriptor.m_id == MaterialID::Water &&
-		            Desc_GetHasReflection() &&
-		            !GetImage(eMaterialTexture_CubeMap);
+            HasReflection() &&
+            !GetImage(eMaterialTexture_CubeMap);
     }
-    bool cMaterial::Desc_GetLargeTransperantSurface() const {
-      switch(m_descriptor.m_id) {
-            case MaterialID::Water:
-                return m_descriptor.m_water.m_isLargeSurface;
-            default:
-                break;
+    bool cMaterial::GetLargeTransperantSurface() const {
+        switch (m_descriptor.m_id) {
+        case MaterialID::Water:
+            return m_descriptor.m_water.m_isLargeSurface;
+        default:
+            break;
         }
         return false;
     }
-    float cMaterial::Desc_maxReflectionDistance() const {
-        switch(m_descriptor.m_id) {
-            case MaterialID::Water:
-                return m_descriptor.m_water.m_maxReflectionDistance;
-            default:
-                break;
+    float cMaterial::GetMaxReflectionDistance() const {
+        switch (m_descriptor.m_id) {
+        case MaterialID::Water:
+            return m_descriptor.m_water.m_reflectionFadeEnd;
+        default:
+            break;
         }
         return 0.0f;
     }
 
-    void cMaterial::UpdateFlags() {
-		const auto alphaMapImage = GetImage(eMaterialTexture_Alpha);
-		const auto heightMapImage = GetImage(eMaterialTexture_Height);
-	    m_info.m_data.m_common.m_materialConfig =
-					(GetImage(eMaterialTexture_Diffuse) ? material::EnableDiffuse: 0) |
-					(GetImage(eMaterialTexture_NMap) ? material::EnableNormal: 0) |
- 					(GetImage(eMaterialTexture_Specular) ? material::EnableSpecular: 0) |
-					(alphaMapImage ? material::EnableAlpha: 0) |
-					(heightMapImage ? material::EnableHeight: 0) |
-					(GetImage(eMaterialTexture_Illumination) ? material::EnableIllumination: 0) |
-					(GetImage(eMaterialTexture_CubeMap) ? material::EnableCubeMap: 0) |
-					(GetImage(eMaterialTexture_DissolveAlpha) ? material::EnableDissolveAlpha: 0) |
-					(GetImage(eMaterialTexture_CubeMapAlpha) ? material::EnableCubeMapAlpha: 0) |
-					(m_info.m_alphaDissolveFilter ? material::UseDissolveFilter: 0);
-		switch(m_info.m_id) {
-			case MaterialID::SolidDiffuse: {
-				m_info.m_data.m_common.m_materialConfig |=
-					((alphaMapImage && TinyImageFormat_ChannelCount(static_cast<TinyImageFormat>(alphaMapImage->GetTexture().m_handle->mFormat)) == 1) ? material::IsAlphaSingleChannel: 0) |
-					((heightMapImage && TinyImageFormat_ChannelCount(static_cast<TinyImageFormat>(heightMapImage->GetTexture().m_handle->mFormat)) == 1) ? material::IsHeightMapSingleChannel: 0);
-				break;
-			}
-			case MaterialID::Translucent: {
-				m_info.m_data.m_common.m_materialConfig |=
-					(HasRefraction() ? material::UseRefractionNormals: 0)  |
-					(IsRefractionEdgeCheck() ? material::UseRefractionEdgeCheck: 0);
-			    break;
-			}
-			default:
-				break;
-		}
-	}
-
-	void cMaterial::SetImage(eMaterialTexture aType, iResourceBase *apTexture)
-	{
-		// increase version number to dirty material
-		UpdateFlags();
-		m_image[aType].SetAutoDestroyResource(false);
-		if(apTexture) {
-			ASSERT(TypeInfo<Image>().IsType(*apTexture) || TypeInfo<AnimatedImage>().IsType(*apTexture) && "cMaterial::SetImage: apTexture is not an Image");
-			m_image[aType] = std::move(ImageResourceWrapper(mpResources->GetTextureManager(), apTexture, mbAutoDestroyTextures));
-		} else {
-			m_image[aType] = ImageResourceWrapper();
-		}
-        Dirty();
-	}
+    void cMaterial::SetImage(eMaterialTexture aType, iResourceBase* apTexture) {
+        // increase version number to dirty material
+        m_image[aType].SetAutoDestroyResource(false);
+        if (apTexture) {
+            ASSERT(
+                TypeInfo<Image>().IsType(*apTexture) ||
+                TypeInfo<AnimatedImage>().IsType(*apTexture) && "cMaterial::SetImage: apTexture is not an Image");
+            m_image[aType] = std::move(ImageResourceWrapper(mpResources->GetTextureManager(), apTexture, mbAutoDestroyTextures));
+        } else {
+            m_image[aType] = ImageResourceWrapper();
+        }
+        IncreaseGeneration();
+    }
 
     Image* cMaterial::GetImage(eMaterialTexture aType) {
         return m_image[aType].GetImage();
@@ -284,125 +173,98 @@ namespace hpl {
         return m_image[aType].GetImage();
     }
 
-    cResourceVarsObject* cMaterial::GetVarsObject()
-	{
-		cResourceVarsObject* pVarsObject = hplNew(cResourceVarsObject,());
-		mpType->GetVariableValues(this, pVarsObject);
+    void cMaterial::SetAutoDestroyTextures(bool abX) {
+        mbAutoDestroyTextures = abX;
+        for (auto& image : m_image) {
+            image.SetAutoDestroyResource(abX);
+        }
+    }
 
-		return pVarsObject;
-	}
+   // cResourceVarsObject* cMaterial::GetVarsObject() {
+   //     cResourceVarsObject* pVarsObject = hplNew(cResourceVarsObject, ());
+   //     mpType->GetVariableValues(this, pVarsObject);
 
-	void cMaterial::LoadVariablesFromVarsObject(cResourceVarsObject* apVarsObject)
-	{
-		mpType->LoadVariables(this, apVarsObject);
-	}
+   //     return pVarsObject;
+   // }
 
-	void cMaterial::SetBlendMode(eMaterialBlendMode aBlendMode)
-	{
-		if(mpType->IsTranslucent()==false) return;
+   // void cMaterial::LoadVariablesFromVarsObject(cResourceVarsObject* apVarsObject) {
+   //     mpType->LoadVariables(this, apVarsObject);
+   // }
 
-		mBlendMode = aBlendMode;
-	}
+    void cMaterial::setTextureFilter(eTextureFilter filter) {
+        m_textureFilter = filter;
+        IncreaseGeneration();
+    }
 
-	void cMaterial::SetAlphaMode(eMaterialAlphaMode aAlphaMode)
-	{
-		//if(mpType->IsTranslucent()) return;
+    void cMaterial::setTextureWrap(eTextureWrap wrap) {
+        m_textureWrap = wrap;
+        IncreaseGeneration();
+    }
 
-		mAlphaMode = aAlphaMode;
-	}
+    void cMaterial::SetDepthTest(bool abDepthTest) {
+        mbDepthTest = abDepthTest;
+        IncreaseGeneration();
+    }
 
-	void cMaterial::SetDepthTest(bool abDepthTest)
-	{
-		if(mpType->IsTranslucent()==false) return;
+    static cVector3f GetAxisVector(eMaterialAnimationAxis aAxis) {
+        switch (aAxis) {
+        case eMaterialAnimationAxis_X:
+            return cVector3f(1, 0, 0);
+        case eMaterialAnimationAxis_Y:
+            return cVector3f(0, 1, 0);
+        case eMaterialAnimationAxis_Z:
+            return cVector3f(0, 0, 1);
+        default:
+            break;
+        }
+        return 0;
+    }
 
-		mbDepthTest = abDepthTest;
-	}
+    void cMaterial::UpdateBeforeRendering(float afTimeStep) {
+        if(!mvUvAnimations.empty()) {
+            m_mtxUV = cMatrixf::Identity;
+            for (size_t i = 0; i < mvUvAnimations.size(); ++i) {
+                cMaterialUvAnimation* pAnim = &mvUvAnimations[i];
+                switch(pAnim->mType) {
+                    case eMaterialUvAnimation_Translate: {
+                        cVector3f vDir = GetAxisVector(pAnim->mAxis);
+                        cMatrixf mtxAdd = cMath::MatrixTranslate(vDir * pAnim->mfSpeed * mfAnimTime);
+                        m_mtxUV = cMath::MatrixMul(m_mtxUV, mtxAdd);
+                        break;
+                    }
+                    case eMaterialUvAnimation_Sin: {
+                        cVector3f vDir = GetAxisVector(pAnim->mAxis);
+                        cMatrixf mtxAdd = cMath::MatrixTranslate(vDir * sin(mfAnimTime * pAnim->mfSpeed) * pAnim->mfAmp);
+                        m_mtxUV = cMath::MatrixMul(m_mtxUV, mtxAdd);
+                        break;
+                    }
+                    case eMaterialUvAnimation_Rotate: {
+                        cVector3f vDir = GetAxisVector(pAnim->mAxis);
 
-	//-----------------------------------------------------------------------
+                        cMatrixf mtxRot = cMath::MatrixRotate(vDir * pAnim->mfSpeed * mfAnimTime, eEulerRotationOrder_XYZ);
+                        m_mtxUV = cMath::MatrixMul(m_mtxUV, mtxRot);
+                        break;
+                    }
+                    default: {
+                        ASSERT(false && "Unknown Animation Type");
+                        break;
+                    }
+                }
+            }
+            IncreaseGeneration();
+            mfAnimTime += afTimeStep;
+        }
+    }
 
-	void cMaterial::UpdateBeforeRendering(float afTimeStep)
-	{
-		if(mbHasUvAnimation) UpdateAnimations(afTimeStep);
-	}
+    void cMaterial::AddUvAnimation(eMaterialUvAnimation aType, float afSpeed, float afAmp, eMaterialAnimationAxis aAxis) {
+        mvUvAnimations.push_back(cMaterialUvAnimation(aType, afSpeed, afAmp, aAxis));
+    }
 
-	//-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
 
-	void cMaterial::AddUvAnimation(eMaterialUvAnimation aType, float afSpeed, float afAmp, eMaterialAnimationAxis aAxis)
-	{
-		mvUvAnimations.push_back(cMaterialUvAnimation(aType, afSpeed, afAmp, aAxis));
+    void cMaterial::ClearUvAnimations() {
+        mvUvAnimations.clear();
+        m_mtxUV = cMatrixf::Identity;
+    }
 
-		mbHasUvAnimation = true;
-	}
-
-	//-----------------------------------------------------------------------
-
-	void cMaterial::ClearUvAnimations()
-	{
-		mvUvAnimations.clear();
-
-		mbHasUvAnimation = false;
-
-		m_mtxUV = cMatrixf::Identity;
-	}
-
-	static cVector3f GetAxisVector(eMaterialAnimationAxis aAxis)
-	{
-		switch(aAxis)
-		{
-		case eMaterialAnimationAxis_X: return cVector3f(1,0,0);
-		case eMaterialAnimationAxis_Y: return cVector3f(0,1,0);
-		case eMaterialAnimationAxis_Z: return cVector3f(0,0,1);
-		}
-		return 0;
-	}
-
-	void cMaterial::UpdateAnimations(float afTimeStep) {
-		m_mtxUV = cMatrixf::Identity;
-
-        for(size_t i=0; i<mvUvAnimations.size(); ++i)
-		{
-			cMaterialUvAnimation *pAnim = &mvUvAnimations[i];
-
-			///////////////////////////
-			// Translate
-			if(pAnim->mType == eMaterialUvAnimation_Translate)
-			{
-				cVector3f vDir = GetAxisVector(pAnim->mAxis);
-
-				cMatrixf mtxAdd = cMath::MatrixTranslate(vDir * pAnim->mfSpeed * mfAnimTime);
-				m_mtxUV = cMath::MatrixMul(m_mtxUV, mtxAdd);
-			}
-			///////////////////////////
-			// Sin
-			else if(pAnim->mType == eMaterialUvAnimation_Sin)
-			{
-				cVector3f vDir = GetAxisVector(pAnim->mAxis);
-
-				cMatrixf mtxAdd = cMath::MatrixTranslate(vDir * sin(mfAnimTime * pAnim->mfSpeed) * pAnim->mfAmp);
-				m_mtxUV = cMath::MatrixMul(m_mtxUV, mtxAdd);
-			}
-			///////////////////////////
-			// Rotate
-			else if(pAnim->mType == eMaterialUvAnimation_Rotate)
-			{
-				cVector3f vDir = GetAxisVector(pAnim->mAxis);
-
-				cMatrixf mtxRot = cMath::MatrixRotate(vDir * pAnim->mfSpeed * mfAnimTime,eEulerRotationOrder_XYZ);
-				m_mtxUV = cMath::MatrixMul(m_mtxUV, mtxRot);
-			}
-		}
-
-		// auto frame = Interface<ForgeRenderer>::Get()->GetFrame();
-		// auto& handle = m_bufferHandle[frame.m_frameIndex];
-		// BufferUpdateDesc uniformUpdate = { handle.m_handle};
-		// beginUpdateResource(&uniformUpdate);
-		// reinterpret_cast<MaterialCommonBlock*>(uniformUpdate.pMappedData)->m_textureMatrix = cMath::ToForgeMat4(m_mtxUV);
-		// endUpdateResource(&uniformUpdate, nullptr);
-
-		m_version++;
-		mfAnimTime += afTimeStep;
-	}
-
-	//-----------------------------------------------------------------------
-
-}
+} // namespace hpl

--- a/HPL2/sources/graphics/Material.cpp
+++ b/HPL2/sources/graphics/Material.cpp
@@ -40,25 +40,14 @@
 namespace hpl {
 
     cMaterial::cMaterial(
-        const tString& asName, const tWString& asFullPath, cGraphics* apGraphics, cResources* apResources)
-        : iResourceBase(asName, asFullPath, 0) {
+        const tString& asName, const tWString& asFullPath, cResources* apResources)
+        : iResourceBase(asName, asFullPath, 0),
+          mpResources(apResources) {
         m_generation = rand();
         m_descriptor.m_id = MaterialID::Unknown;
-        mpGraphics = apGraphics;
-        mpResources = apResources;
-
-        mfAnimTime = 0;
-        m_mtxUV = cMatrixf::Identity;
-
-        mbDepthTest = true;
     }
-
-    //-----------------------------------------------------------------------
 
     cMaterial::~cMaterial() {
-    }
-
-    void cMaterial::Compile() {
     }
 
     void cMaterial::SetTextureAnisotropy(float afx) {

--- a/HPL2/sources/graphics/MaterialResource.cpp
+++ b/HPL2/sources/graphics/MaterialResource.cpp
@@ -29,14 +29,14 @@ namespace hpl::material {
             case hpl::MaterialID::Water:
                 block.m_water.mfRefractionScale = descriptor.m_water.m_refractionScale;
  		        block.m_water.mfFrenselBias = descriptor.m_water.m_frenselBias;
-		        block.m_water.mfFrenselPow = descriptor.m_water.mfFrenselPow;
+		        block.m_water.mfFrenselPow = descriptor.m_water.m_frenselPow;
 
-		        block.m_water.m_reflectionFadeStart = descriptor.m_water.mfReflectionFadeStart;
-		        block.m_water.m_reflectionFadeEnd = descriptor.m_water.mfReflectionFadeEnd;
-		        block.m_water.m_waveSpeed = descriptor.m_water.mfWaveSpeed;
-		        block.m_water.mfWaveAmplitude = descriptor.m_water.mfWaveAmplitude;
+		        block.m_water.m_reflectionFadeStart = descriptor.m_water.m_reflectionFadeStart;
+		        block.m_water.m_reflectionFadeEnd = descriptor.m_water.m_reflectionFadeEnd;
+		        block.m_water.m_waveSpeed = descriptor.m_water.m_waveSpeed;
+		        block.m_water.mfWaveAmplitude = descriptor.m_water.m_waveAmplitude;
 
-		        block.m_water.mfWaveFreq = descriptor.m_water.mfWaveFreq;
+		        block.m_water.mfWaveFreq = descriptor.m_water.m_waveFreq;
 
                 break;
             default:

--- a/HPL2/sources/graphics/MaterialResource.cpp
+++ b/HPL2/sources/graphics/MaterialResource.cpp
@@ -1,0 +1,80 @@
+#include "tinyimageformat_query.h"
+#include <graphics/MaterialResource.h>
+#include <graphics/Material.h>
+
+namespace hpl::material {
+
+    UniformMaterialBlock UniformMaterialBlock::CreateFromMaterial(cMaterial &material) {
+        UniformMaterialBlock  block = {};
+        auto& descriptor = material.Descriptor();
+		const auto alphaMapImage = material.GetImage(eMaterialTexture_Alpha);
+		const auto heightMapImage = material.GetImage(eMaterialTexture_Height);
+        block.m_common.m_materialConfig = UniformMaterialBlock::CreateMaterailConfigFlags(material);
+        switch(descriptor.m_id) {
+            case hpl::MaterialID::SolidDiffuse:
+                block.m_solid.m_heightMapScale = descriptor.m_solid.m_heightMapScale;
+                block.m_solid.m_heightMapBias = descriptor.m_solid.m_heightMapBias;
+                block.m_solid.m_frenselBias = descriptor.m_solid.m_frenselBias;
+                block.m_solid.m_frenselPow = descriptor.m_solid.m_frenselPow;
+                break;
+            case hpl::MaterialID::Decal:
+                break;
+            case hpl::MaterialID::Translucent:
+                block.m_translucent.m_refractionScale = descriptor.m_translucent.m_refractionScale;
+                block.m_translucent.m_frenselBias = descriptor.m_translucent.m_frenselBias;
+                block.m_translucent.m_frenselPow = descriptor.m_translucent.m_frenselPow;
+                block.m_translucent.mfRimLightMul = descriptor.m_translucent.m_rimLightMul;
+                block.m_translucent.mfRimLightPow = descriptor.m_translucent.m_rimLightPow;
+                break;
+            case hpl::MaterialID::Water:
+                block.m_water.mfRefractionScale = descriptor.m_water.m_refractionScale;
+ 		        block.m_water.mfFrenselBias = descriptor.m_water.m_frenselBias;
+		        block.m_water.mfFrenselPow = descriptor.m_water.mfFrenselPow;
+
+		        block.m_water.m_reflectionFadeStart = descriptor.m_water.mfReflectionFadeStart;
+		        block.m_water.m_reflectionFadeEnd = descriptor.m_water.mfReflectionFadeEnd;
+		        block.m_water.m_waveSpeed = descriptor.m_water.mfWaveSpeed;
+		        block.m_water.mfWaveAmplitude = descriptor.m_water.mfWaveAmplitude;
+
+		        block.m_water.mfWaveFreq = descriptor.m_water.mfWaveFreq;
+
+                break;
+            default:
+                ASSERT(false && "unhandeled material config");
+                break;
+        }
+        return block;
+    }
+
+    uint32_t UniformMaterialBlock::CreateMaterailConfigFlags(cMaterial& material) {
+	    const auto alphaMapImage = material.GetImage(eMaterialTexture_Alpha);
+		const auto heightMapImage = material.GetImage(eMaterialTexture_Height);
+        uint32_t flags =
+			(material.GetImage(eMaterialTexture_Diffuse) ? EnableDiffuse: 0) |
+			(material.GetImage(eMaterialTexture_NMap) ? EnableNormal: 0) |
+ 			(material.GetImage(eMaterialTexture_Specular) ? EnableSpecular: 0) |
+			(alphaMapImage ? EnableAlpha: 0) |
+			(heightMapImage ? EnableHeight: 0) |
+			(material.GetImage(eMaterialTexture_Illumination) ? EnableIllumination: 0) |
+			(material.GetImage(eMaterialTexture_CubeMap) ? EnableCubeMap: 0) |
+			(material.GetImage(eMaterialTexture_DissolveAlpha) ? EnableDissolveAlpha: 0) |
+			(material.GetImage(eMaterialTexture_CubeMapAlpha) ? EnableCubeMapAlpha: 0) |
+			((alphaMapImage && TinyImageFormat_ChannelCount(static_cast<TinyImageFormat>(alphaMapImage->GetTexture().m_handle->mFormat)) == 1) ? IsAlphaSingleChannel: 0) |
+			((heightMapImage && TinyImageFormat_ChannelCount(static_cast<TinyImageFormat>(heightMapImage->GetTexture().m_handle->mFormat)) == 1) ? IsHeightMapSingleChannel: 0);
+        auto& descriptor = material.Descriptor();
+        switch(descriptor.m_id) {
+            case hpl::MaterialID::SolidDiffuse:
+                flags |=
+                    (descriptor.m_solid.m_alphaDissolveFilter ? UseDissolveFilter : 0);
+                break;
+            case hpl::MaterialID::Translucent:
+                flags |=
+                    (descriptor.m_translucent.m_hasRefraction ? UseRefractionNormals : 0) |
+                    (descriptor.m_translucent.m_hasRefraction && descriptor.m_translucent.m_refractionEdgeCheck ? UseRefractionEdgeCheck : 0);
+                break;
+            default:
+                break;
+        }
+        return flags;
+    }
+};

--- a/HPL2/sources/graphics/MaterialType_BasicSolid.cpp
+++ b/HPL2/sources/graphics/MaterialType_BasicSolid.cpp
@@ -85,14 +85,14 @@ namespace hpl
 
     void iMaterialType_SolidBase::CompileMaterialSpecifics(cMaterial* apMaterial)
     {
-        if (apMaterial->GetImage(eMaterialTexture_Alpha))
-        {
-            apMaterial->SetAlphaMode(eMaterialAlphaMode_Trans);
-        }
-        else
-        {
-            apMaterial->SetAlphaMode(eMaterialAlphaMode_Solid);
-        }
+       // if (apMaterial->GetImage(eMaterialTexture_Alpha))
+       // {
+       //     apMaterial->SetAlphaMode(eMaterialAlphaMode_Trans);
+       // }
+       // else
+       // {
+       //     apMaterial->SetAlphaMode(eMaterialAlphaMode_Solid);
+       // }
 
         CompileSolidSpecifics(apMaterial);
     }
@@ -132,12 +132,12 @@ namespace hpl
 
     void cMaterialType_SolidDiffuse::CompileSolidSpecifics(cMaterial* apMaterial)
     {
-        cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
+        //cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
 
         //////////////////////////////////
         // Z specifics
-        apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Z_Dissolve, true);
-        apMaterial->SetUseAlphaDissolveFilter(pVars->mbAlphaDissolveFilter);
+      //  apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Z_Dissolve, true);
+        //apMaterial->SetUseAlphaDissolveFilter(pVars->mbAlphaDissolveFilter);
 
         //////////////////////////////////
         // Normal map and height specifics
@@ -145,31 +145,31 @@ namespace hpl
         {
             if (apMaterial->GetImage(eMaterialTexture_Height))
             {
-                apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
+   //             apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
             }
         }
 
         //////////////////////////////////
-        // Uv animation specifics
-        if (apMaterial->HasUvAnimation())
-        {
-            apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Z, true);
-            apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-            apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Illumination, true);
-        }
+     //   // Uv animation specifics
+     //   if (apMaterial->HasUvAnimation())
+     //   {
+     // //      apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Z, true);
+     // //      apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
+     // //      apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Illumination, true);
+     //   }
 
         //////////////////////////////////
         // Cubemap
         if (apMaterial->GetImage(eMaterialTexture_CubeMap))
         {
-            apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
+     //       apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
         }
 
         //////////////////////////////////
         // Illuminations specifics
         if (apMaterial->GetImage(eMaterialTexture_Illumination))
         {
-            apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Illumination, true);
+    //        apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Illumination, true);
         }
     }
 
@@ -210,31 +210,31 @@ namespace hpl
 
     void cMaterialType_SolidDiffuse::LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars)
     {
-        cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
-        if (pVars == NULL)
-        {
-            pVars = (cMaterialType_SolidDiffuse_Vars*)CreateSpecificVariables();
-            apMaterial->SetVars(pVars);
-        }
+      //  cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
+      //  if (pVars == NULL)
+      //  {
+      //      pVars = (cMaterialType_SolidDiffuse_Vars*)CreateSpecificVariables();
+      //      apMaterial->SetVars(pVars);
+      //  }
 
-        pVars->mfHeightMapScale = apVars->GetVarFloat("HeightMapScale", 0.1f);
-        pVars->mfHeightMapBias = apVars->GetVarFloat("HeightMapBias", 0);
-        pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
-        pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0f);
-        pVars->mbAlphaDissolveFilter = apVars->GetVarBool("AlphaDissolveFilter", false);
+      //  pVars->mfHeightMapScale = apVars->GetVarFloat("HeightMapScale", 0.1f);
+      //  pVars->mfHeightMapBias = apVars->GetVarFloat("HeightMapBias", 0);
+      //  pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
+      //  pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0f);
+      //  pVars->mbAlphaDissolveFilter = apVars->GetVarBool("AlphaDissolveFilter", false);
     }
 
     //--------------------------------------------------------------------------
 
     void cMaterialType_SolidDiffuse::GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars)
     {
-        cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
-
-        apVars->AddVarFloat("HeightMapScale", pVars->mfHeightMapScale);
-        apVars->AddVarFloat("HeightMapBias", pVars->mfHeightMapBias);
-        apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
-        apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
-        apVars->AddVarBool("AlphaDissolveFilter", pVars->mbAlphaDissolveFilter);
+//        cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
+//
+//        apVars->AddVarFloat("HeightMapScale", pVars->mfHeightMapScale);
+//        apVars->AddVarFloat("HeightMapBias", pVars->mfHeightMapBias);
+//        apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
+//        apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
+//        apVars->AddVarBool("AlphaDissolveFilter", pVars->mbAlphaDissolveFilter);
     }
 
     //--------------------------------------------------------------------------

--- a/HPL2/sources/graphics/MaterialType_BasicSolid.cpp
+++ b/HPL2/sources/graphics/MaterialType_BasicSolid.cpp
@@ -57,7 +57,6 @@ namespace hpl
 
     iMaterialType_SolidBase::~iMaterialType_SolidBase()
     {
-        mpResources->GetTextureManager()->Destroy(m_dissolveImage);
     }
 
     void iMaterialType_SolidBase::CreateGlobalPrograms()
@@ -67,7 +66,6 @@ namespace hpl
     void iMaterialType_SolidBase::LoadData()
     {
         CreateGlobalPrograms();
-        m_dissolveImage = mpResources->GetTextureManager()->Create2DImage("core_dissolve.tga", true);
     }
 
     void iMaterialType_SolidBase::DestroyData()
@@ -85,15 +83,6 @@ namespace hpl
 
     void iMaterialType_SolidBase::CompileMaterialSpecifics(cMaterial* apMaterial)
     {
-       // if (apMaterial->GetImage(eMaterialTexture_Alpha))
-       // {
-       //     apMaterial->SetAlphaMode(eMaterialAlphaMode_Trans);
-       // }
-       // else
-       // {
-       //     apMaterial->SetAlphaMode(eMaterialAlphaMode_Solid);
-       // }
-
         CompileSolidSpecifics(apMaterial);
     }
 
@@ -132,110 +121,24 @@ namespace hpl
 
     void cMaterialType_SolidDiffuse::CompileSolidSpecifics(cMaterial* apMaterial)
     {
-        //cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
-
-        //////////////////////////////////
-        // Z specifics
-      //  apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Z_Dissolve, true);
-        //apMaterial->SetUseAlphaDissolveFilter(pVars->mbAlphaDissolveFilter);
-
-        //////////////////////////////////
-        // Normal map and height specifics
-        if (apMaterial->GetImage(eMaterialTexture_NMap))
-        {
-            if (apMaterial->GetImage(eMaterialTexture_Height))
-            {
-   //             apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-            }
-        }
-
-        //////////////////////////////////
-     //   // Uv animation specifics
-     //   if (apMaterial->HasUvAnimation())
-     //   {
-     // //      apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Z, true);
-     // //      apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-     // //      apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Illumination, true);
-     //   }
-
-        //////////////////////////////////
-        // Cubemap
-        if (apMaterial->GetImage(eMaterialTexture_CubeMap))
-        {
-     //       apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-        }
-
-        //////////////////////////////////
-        // Illuminations specifics
-        if (apMaterial->GetImage(eMaterialTexture_Illumination))
-        {
-    //        apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Illumination, true);
-        }
     }
 
 
     iMaterialVars* cMaterialType_SolidDiffuse::CreateSpecificVariables()
     {
-        auto pVars = new cMaterialType_SolidDiffuse_Vars();
-        auto pipeline = Interface<ForgeRenderer>::Get();
-        DescriptorSetDesc desc = { pipeline->PipelineSignature(), DESCRIPTOR_UPDATE_FREQ_PER_FRAME, 2 };
-
-        BufferDesc bufferDesc = {};
-        bufferDesc.mDescriptors = DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        bufferDesc.mMemoryUsage = RESOURCE_MEMORY_USAGE_CPU_TO_GPU;
-        bufferDesc.mFlags = BUFFER_CREATION_FLAG_PERSISTENT_MAP_BIT;
-        bufferDesc.mSize = sizeof(cMaterialType_SolidDiffuse_Vars::MaterialBufferData);
-        pVars->m_materialId = (++m_materialCount) % MaxSolidMaterials;
-        // for(auto& bufferHandle: pVars->m_diffuseBuffer) {
-        //     BufferLoadDesc loadDesc = {};
-        //     loadDesc.mDesc = bufferDesc;
-        //     loadDesc.ppBuffer = &bufferHandle.m_handle;
-        //     addResource(&loadDesc, nullptr);
-        // }
-        // DescriptorSet* descriptorSet = {};
-        // addDescriptorSet(pipeline->Rend(), &desc, &pVars->m_descriptorSet[eMaterialRenderMode_Diffuse].m_handle);
-        // addDescriptorSet(pipeline->Rend(), &desc, &pVars->m_descriptorSet[eMaterialRenderMode_Z].m_handle);
-        // addDescriptorSet(pipeline->Rend(), &desc, &pVars->m_descriptorSet[eMaterialRenderMode_Z_Dissolve].m_handle);
-        // addDescriptorSet(pipeline->Rend(), &desc, &pVars->m_descriptorSet[eMaterialRenderMode_Illumination].m_handle);
-
-        // pVars->m_descriptorSet[eMaterialRenderMode_Diffuse].Initialize();
-        // pVars->m_descriptorSet[eMaterialRenderMode_Z].Initialize();
-        // pVars->m_descriptorSet[eMaterialRenderMode_Z_Dissolve].Initialize();
-        // pVars->m_descriptorSet[eMaterialRenderMode_Illumination].Initialize();
-
-        return new cMaterialType_SolidDiffuse_Vars();
+        return nullptr;
     }
 
     //--------------------------------------------------------------------------
 
     void cMaterialType_SolidDiffuse::LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars)
     {
-      //  cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
-      //  if (pVars == NULL)
-      //  {
-      //      pVars = (cMaterialType_SolidDiffuse_Vars*)CreateSpecificVariables();
-      //      apMaterial->SetVars(pVars);
-      //  }
-
-      //  pVars->mfHeightMapScale = apVars->GetVarFloat("HeightMapScale", 0.1f);
-      //  pVars->mfHeightMapBias = apVars->GetVarFloat("HeightMapBias", 0);
-      //  pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
-      //  pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0f);
-      //  pVars->mbAlphaDissolveFilter = apVars->GetVarBool("AlphaDissolveFilter", false);
     }
 
     //--------------------------------------------------------------------------
 
     void cMaterialType_SolidDiffuse::GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars)
     {
-//        cMaterialType_SolidDiffuse_Vars* pVars = (cMaterialType_SolidDiffuse_Vars*)apMaterial->GetVars();
-//
-//        apVars->AddVarFloat("HeightMapScale", pVars->mfHeightMapScale);
-//        apVars->AddVarFloat("HeightMapBias", pVars->mfHeightMapBias);
-//        apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
-//        apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
-//        apVars->AddVarBool("AlphaDissolveFilter", pVars->mbAlphaDissolveFilter);
     }
 
-    //--------------------------------------------------------------------------
 } // namespace hpl

--- a/HPL2/sources/graphics/MaterialType_BasicTranslucent.cpp
+++ b/HPL2/sources/graphics/MaterialType_BasicTranslucent.cpp
@@ -102,9 +102,7 @@ namespace hpl
 
     iMaterialVars* cMaterialType_Translucent::CreateSpecificVariables()
     {
-        cMaterialType_Translucent_Vars* pVars = hplNew(cMaterialType_Translucent_Vars, ());
-
-        return pVars;
+        return nullptr;
     }
 
     //--------------------------------------------------------------------------

--- a/HPL2/sources/graphics/MaterialType_BasicTranslucent.cpp
+++ b/HPL2/sources/graphics/MaterialType_BasicTranslucent.cpp
@@ -111,65 +111,65 @@ namespace hpl
 
     void cMaterialType_Translucent::LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars)
     {
-        cMaterialType_Translucent_Vars* pVars = (cMaterialType_Translucent_Vars*)apMaterial->GetVars();
-        if (pVars == NULL)
-        {
-            pVars = static_cast<cMaterialType_Translucent_Vars*>(CreateSpecificVariables());
-            apMaterial->SetVars(pVars);
-        }
+       // cMaterialType_Translucent_Vars* pVars = (cMaterialType_Translucent_Vars*)apMaterial->GetVars();
+       // if (pVars == NULL)
+       // {
+       //     pVars = static_cast<cMaterialType_Translucent_Vars*>(CreateSpecificVariables());
+       //     apMaterial->SetVars(pVars);
+       // }
 
-        pVars->mbRefraction = apVars->GetVarBool("Refraction", false);
-        pVars->mbRefractionEdgeCheck = apVars->GetVarBool("RefractionEdgeCheck", true);
-        pVars->mbRefractionNormals = apVars->GetVarBool("RefractionNormals", true);
-        pVars->mfRefractionScale = apVars->GetVarFloat("RefractionScale", 1.0f);
-        pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
-        pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0);
-        pVars->mfRimLightMul = apVars->GetVarFloat("RimLightMul", 0.0f);
-        pVars->mfRimLightPow = apVars->GetVarFloat("RimLightPow", 8.0f);
-        pVars->mbAffectedByLightLevel = apVars->GetVarBool("AffectedByLightLevel", false);
+       // pVars->mbRefraction = apVars->GetVarBool("Refraction", false);
+       // pVars->mbRefractionEdgeCheck = apVars->GetVarBool("RefractionEdgeCheck", true);
+       // pVars->mbRefractionNormals = apVars->GetVarBool("RefractionNormals", true);
+       // pVars->mfRefractionScale = apVars->GetVarFloat("RefractionScale", 1.0f);
+       // pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
+       // pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0);
+       // pVars->mfRimLightMul = apVars->GetVarFloat("RimLightMul", 0.0f);
+       // pVars->mfRimLightPow = apVars->GetVarFloat("RimLightPow", 8.0f);
+       // pVars->mbAffectedByLightLevel = apVars->GetVarBool("AffectedByLightLevel", false);
     }
 
     //--------------------------------------------------------------------------
 
     void cMaterialType_Translucent::GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars)
     {
-        cMaterialType_Translucent_Vars* pVars = (cMaterialType_Translucent_Vars*)apMaterial->GetVars();
+      //  cMaterialType_Translucent_Vars* pVars = (cMaterialType_Translucent_Vars*)apMaterial->GetVars();
 
-        apVars->AddVarBool("Refraction", pVars->mbRefraction);
-        apVars->AddVarBool("RefractionEdgeCheck", pVars->mbRefractionEdgeCheck);
-        apVars->AddVarBool("RefractionNormals", pVars->mbRefractionNormals);
-        apVars->AddVarFloat("RefractionScale", pVars->mfRefractionScale);
-        apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
-        apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
-        apVars->AddVarFloat("RimLightMul", pVars->mfRimLightMul);
-        apVars->AddVarFloat("RimLightPow", pVars->mfRimLightPow);
-        apVars->AddVarBool("AffectedByLightLevel", pVars->mbAffectedByLightLevel);
+      //  apVars->AddVarBool("Refraction", pVars->mbRefraction);
+      //  apVars->AddVarBool("RefractionEdgeCheck", pVars->mbRefractionEdgeCheck);
+      //  apVars->AddVarBool("RefractionNormals", pVars->mbRefractionNormals);
+      //  apVars->AddVarFloat("RefractionScale", pVars->mfRefractionScale);
+      //  apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
+      //  apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
+      //  apVars->AddVarFloat("RimLightMul", pVars->mfRimLightMul);
+      //  apVars->AddVarFloat("RimLightPow", pVars->mfRimLightPow);
+      //  apVars->AddVarBool("AffectedByLightLevel", pVars->mbAffectedByLightLevel);
     }
 
     //--------------------------------------------------------------------------
 
     void cMaterialType_Translucent::CompileMaterialSpecifics(cMaterial* apMaterial)
     {
-        cMaterialType_Translucent_Vars* pVars = static_cast<cMaterialType_Translucent_Vars*>(apMaterial->GetVars());
+      //  cMaterialType_Translucent_Vars* pVars = static_cast<cMaterialType_Translucent_Vars*>(apMaterial->GetVars());
 
         /////////////////////////////////////
         // Set up specifics
-        apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-        apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Diffuse, true);
+       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
+       // apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Diffuse, true);
 
-        apMaterial->SetHasSpecificSettings(eMaterialRenderMode_DiffuseFog, true);
-        apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_DiffuseFog, true);
+       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_DiffuseFog, true);
+       // apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_DiffuseFog, true);
 
-        apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Illumination, true);
-        apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Illumination, true);
+       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Illumination, true);
+       // apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_Illumination, true);
 
-        apMaterial->SetHasSpecificSettings(eMaterialRenderMode_IlluminationFog, true);
-        apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_IlluminationFog, true);
+       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_IlluminationFog, true);
+       // apMaterial->SetHasObjectSpecificsSettings(eMaterialRenderMode_IlluminationFog, true);
 
         /////////////////////////////////////
         // Set up the refraction
-         apMaterial->SetHasRefraction(pVars->mbRefraction);
-         apMaterial->SetUseRefractionEdgeCheck(pVars->mbRefractionEdgeCheck);
+        // apMaterial->SetHasRefraction(pVars->mbRefraction);
+        // apMaterial->SetUseRefractionEdgeCheck(pVars->mbRefractionEdgeCheck);
 
 		 //bool bRefractionEnabled = pVars->mbRefraction && iRenderer::GetRefractionEnabled();
          //if (bRefractionEnabled)

--- a/HPL2/sources/graphics/MaterialType_Decal.cpp
+++ b/HPL2/sources/graphics/MaterialType_Decal.cpp
@@ -63,23 +63,23 @@ namespace hpl {
     }
 
     void cMaterialType_Decal::LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-        cMaterialType_Decal_Vars* pVars = (cMaterialType_Decal_Vars*)apMaterial->GetVars();
-        if (pVars == NULL) {
-            pVars = (cMaterialType_Decal_Vars*)CreateSpecificVariables();
-            apMaterial->SetVars(pVars);
-        }
+       // cMaterialType_Decal_Vars* pVars = (cMaterialType_Decal_Vars*)apMaterial->GetVars();
+       // if (pVars == NULL) {
+       //     pVars = (cMaterialType_Decal_Vars*)CreateSpecificVariables();
+       //     apMaterial->SetVars(pVars);
+       // }
     }
 
     void cMaterialType_Decal::GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-        cMaterialType_Decal_Vars* pVars = (cMaterialType_Decal_Vars*)apMaterial->GetVars();
+      //  cMaterialType_Decal_Vars* pVars = (cMaterialType_Decal_Vars*)apMaterial->GetVars();
     }
 
     void cMaterialType_Decal::CompileMaterialSpecifics(cMaterial* apMaterial) {
-        cMaterialType_Decal_Vars* pVars = static_cast<cMaterialType_Decal_Vars*>(apMaterial->GetVars());
+        //cMaterialType_Decal_Vars* pVars = static_cast<cMaterialType_Decal_Vars*>(apMaterial->GetVars());
 
-        if (apMaterial->HasUvAnimation()) {
-            apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-        }
+ //       if (apMaterial->HasUvAnimation()) {
+////            apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
+ //       }
     }
 
 } // namespace hpl

--- a/HPL2/sources/graphics/MaterialType_Decal.cpp
+++ b/HPL2/sources/graphics/MaterialType_Decal.cpp
@@ -59,19 +59,13 @@ namespace hpl {
 
 
     iMaterialVars* cMaterialType_Decal::CreateSpecificVariables() {
-        return hplNew(cMaterialType_Decal_Vars, ());
+        return nullptr;
     }
 
     void cMaterialType_Decal::LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-       // cMaterialType_Decal_Vars* pVars = (cMaterialType_Decal_Vars*)apMaterial->GetVars();
-       // if (pVars == NULL) {
-       //     pVars = (cMaterialType_Decal_Vars*)CreateSpecificVariables();
-       //     apMaterial->SetVars(pVars);
-       // }
     }
 
     void cMaterialType_Decal::GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-      //  cMaterialType_Decal_Vars* pVars = (cMaterialType_Decal_Vars*)apMaterial->GetVars();
     }
 
     void cMaterialType_Decal::CompileMaterialSpecifics(cMaterial* apMaterial) {

--- a/HPL2/sources/graphics/MaterialType_Water.cpp
+++ b/HPL2/sources/graphics/MaterialType_Water.cpp
@@ -72,16 +72,6 @@ namespace hpl {
 
         mbHasTypeSpecifics[eMaterialRenderMode_Diffuse] = true;
         mbHasTypeSpecifics[eMaterialRenderMode_DiffuseFog] = true;
-
-        // m_u_param = bgfx::createUniform("u_param", bgfx::UniformType::Vec4);
-        // m_u_mtxInvViewRotation = bgfx::createUniform("u_mtxInvViewRotation", bgfx::UniformType::Mat4);
-        // m_u_fogColor = bgfx::createUniform("u_fogColor", bgfx::UniformType::Vec4);
-
-        // m_s_diffuseMap = bgfx::createUniform("s_diffuseMap", bgfx::UniformType::Sampler);
-        // m_s_normalMap = bgfx::createUniform("s_normalMap", bgfx::UniformType::Sampler);
-        // m_s_refractionMap = bgfx::createUniform("s_refractionMap", bgfx::UniformType::Sampler);
-        // m_s_reflectionMap = bgfx::createUniform("s_reflectionMap", bgfx::UniformType::Sampler);
-        // m_s_envMap = bgfx::createUniform("s_envMap", bgfx::UniformType::Sampler);
     }
 
     cMaterialType_Water::~cMaterialType_Water() {
@@ -105,74 +95,74 @@ namespace hpl {
     }
 
     void cMaterialType_Water::LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-        cMaterialType_Water_Vars* pVars = (cMaterialType_Water_Vars*)apMaterial->GetVars();
-        if (pVars == NULL) {
-            pVars = (cMaterialType_Water_Vars*)CreateSpecificVariables();
-            apMaterial->SetVars(pVars);
-        }
+       // cMaterialType_Water_Vars* pVars = (cMaterialType_Water_Vars*)apMaterial->GetVars();
+       // if (pVars == NULL) {
+       //     pVars = (cMaterialType_Water_Vars*)CreateSpecificVariables();
+       //     apMaterial->SetVars(pVars);
+       // }
 
-        pVars->mbHasReflection = apVars->GetVarBool("HasReflection", true);
-        pVars->mfRefractionScale = apVars->GetVarFloat("RefractionScale", 0.1f);
-        pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
-        pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0f);
-        pVars->mfReflectionFadeStart = apVars->GetVarFloat("ReflectionFadeStart", 0);
-        pVars->mfReflectionFadeEnd = apVars->GetVarFloat("ReflectionFadeEnd", 0);
-        pVars->mfWaveSpeed = apVars->GetVarFloat("WaveSpeed", 1.0f);
-        pVars->mfWaveAmplitude = apVars->GetVarFloat("WaveAmplitude", 1.0f);
-        pVars->mfWaveFreq = apVars->GetVarFloat("WaveFreq", 1.0f);
+       // pVars->mbHasReflection = apVars->GetVarBool("HasReflection", true);
+       // pVars->mfRefractionScale = apVars->GetVarFloat("RefractionScale", 0.1f);
+       // pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
+       // pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0f);
+       // pVars->mfReflectionFadeStart = apVars->GetVarFloat("ReflectionFadeStart", 0);
+       // pVars->mfReflectionFadeEnd = apVars->GetVarFloat("ReflectionFadeEnd", 0);
+       // pVars->mfWaveSpeed = apVars->GetVarFloat("WaveSpeed", 1.0f);
+       // pVars->mfWaveAmplitude = apVars->GetVarFloat("WaveAmplitude", 1.0f);
+       // pVars->mfWaveFreq = apVars->GetVarFloat("WaveFreq", 1.0f);
 
-        apMaterial->SetWorldReflectionOcclusionTest(apVars->GetVarBool("OcclusionCullWorldReflection", true));
-        apMaterial->SetMaxReflectionDistance(apVars->GetVarFloat("ReflectionFadeEnd", 0.0f));
-        apMaterial->SetLargeTransperantSurface(apVars->GetVarBool("LargeSurface", false));
+       // apMaterial->SetWorldReflectionOcclusionTest(apVars->GetVarBool("OcclusionCullWorldReflection", true));
+       // apMaterial->SetMaxReflectionDistance(apVars->GetVarFloat("ReflectionFadeEnd", 0.0f));
+       // apMaterial->SetLargeTransperantSurface(apVars->GetVarBool("LargeSurface", false));
     }
 
     void cMaterialType_Water::GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-        cMaterialType_Water_Vars* pVars = (cMaterialType_Water_Vars*)apMaterial->GetVars();
+       // cMaterialType_Water_Vars* pVars = (cMaterialType_Water_Vars*)apMaterial->GetVars();
 
-        apVars->AddVarBool("HasReflection", pVars->mbHasReflection);
-        apVars->AddVarFloat("RefractionScale", pVars->mfRefractionScale);
-        apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
-        apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
-        apVars->AddVarFloat("ReflectionFadeStart", pVars->mfReflectionFadeStart);
-        apVars->AddVarFloat("ReflectionFadeEnd", pVars->mfReflectionFadeEnd);
-        apVars->AddVarFloat("WaveSpeed", pVars->mfWaveSpeed);
-        apVars->AddVarFloat("WaveAmplitude", pVars->mfWaveAmplitude);
-        apVars->AddVarFloat("WaveFreq", pVars->mfWaveFreq);
+       // apVars->AddVarBool("HasReflection", pVars->mbHasReflection);
+       // apVars->AddVarFloat("RefractionScale", pVars->mfRefractionScale);
+       // apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
+       // apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
+       // apVars->AddVarFloat("ReflectionFadeStart", pVars->mfReflectionFadeStart);
+       // apVars->AddVarFloat("ReflectionFadeEnd", pVars->mfReflectionFadeEnd);
+       // apVars->AddVarFloat("WaveSpeed", pVars->mfWaveSpeed);
+       // apVars->AddVarFloat("WaveAmplitude", pVars->mfWaveAmplitude);
+       // apVars->AddVarFloat("WaveFreq", pVars->mfWaveFreq);
 
-        apVars->AddVarBool("OcclusionCullWorldReflection", apMaterial->GetWorldReflectionOcclusionTest());
-        apVars->AddVarBool("LargeSurface", apMaterial->GetLargeTransperantSurface());
+       // apVars->AddVarBool("OcclusionCullWorldReflection", apMaterial->GetWorldReflectionOcclusionTest());
+       // apVars->AddVarBool("LargeSurface", apMaterial->GetLargeTransperantSurface());
     }
 
     void cMaterialType_Water::CompileMaterialSpecifics(cMaterial* apMaterial) {
-        cMaterialType_Water_Vars* pVars = static_cast<cMaterialType_Water_Vars*>(apMaterial->GetVars());
+        //cMaterialType_Water_Vars* pVars = static_cast<cMaterialType_Water_Vars*>(apMaterial->GetVars());
 
-        /////////////////////////////////////
-        // Set if has specific variables
-        apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-        apMaterial->SetHasSpecificSettings(eMaterialRenderMode_DiffuseFog, true);
+       // /////////////////////////////////////
+       // // Set if has specific variables
+       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
+       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_DiffuseFog, true);
 
         /////////////////////////////////////
         // Set up the blend mode
-        if (iRenderer::GetRefractionEnabled()) {
-            apMaterial->SetBlendMode(eMaterialBlendMode_None);
-        } else {
-            apMaterial->SetBlendMode(eMaterialBlendMode_Mul);
-        }
+       // if (iRenderer::GetRefractionEnabled()) {
+       //     apMaterial->SetBlendMode(eMaterialBlendMode_None);
+       // } else {
+       //     apMaterial->SetBlendMode(eMaterialBlendMode_Mul);
+       // }
 
-        /////////////////////////////////////
-        // Set up the refraction
-        if (iRenderer::GetRefractionEnabled()) {
-            apMaterial->SetHasRefraction(true);
-            apMaterial->SetUseRefractionEdgeCheck(true);
-        }
+       // /////////////////////////////////////
+       // // Set up the refraction
+       // if (iRenderer::GetRefractionEnabled()) {
+       //     apMaterial->SetHasRefraction(true);
+       //     apMaterial->SetUseRefractionEdgeCheck(true);
+       // }
 
-        ///////////////////////////
-        // Set up reflection
-        if (pVars->mbHasReflection && iRenderer::GetRefractionEnabled()) {
-            if (apMaterial->GetImage(eMaterialTexture_CubeMap) == NULL) {
-                apMaterial->SetHasWorldReflection(true);
-            }
-        }
+       // ///////////////////////////
+       // // Set up reflection
+       // if (pVars->mbHasReflection && iRenderer::GetRefractionEnabled()) {
+       //     if (apMaterial->GetImage(eMaterialTexture_CubeMap) == NULL) {
+       //         apMaterial->SetHasWorldReflection(true);
+       //     }
+       // }
     }
 
 } // namespace hpl

--- a/HPL2/sources/graphics/MaterialType_Water.cpp
+++ b/HPL2/sources/graphics/MaterialType_Water.cpp
@@ -84,85 +84,16 @@ namespace hpl {
     }
 
     iMaterialVars* cMaterialType_Water::CreateSpecificVariables() {
-        cMaterialType_Water_Vars* pVars = hplNew(cMaterialType_Water_Vars, ());
-
-        pVars->mbHasReflection = true;
-        pVars->mfRefractionScale = 0.1f;
-        pVars->mfFrenselBias = 0.2f;
-        pVars->mfFrenselPow = 8.0f;
-
-        return pVars;
+        return nullptr;
     }
 
     void cMaterialType_Water::LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-       // cMaterialType_Water_Vars* pVars = (cMaterialType_Water_Vars*)apMaterial->GetVars();
-       // if (pVars == NULL) {
-       //     pVars = (cMaterialType_Water_Vars*)CreateSpecificVariables();
-       //     apMaterial->SetVars(pVars);
-       // }
-
-       // pVars->mbHasReflection = apVars->GetVarBool("HasReflection", true);
-       // pVars->mfRefractionScale = apVars->GetVarFloat("RefractionScale", 0.1f);
-       // pVars->mfFrenselBias = apVars->GetVarFloat("FrenselBias", 0.2f);
-       // pVars->mfFrenselPow = apVars->GetVarFloat("FrenselPow", 8.0f);
-       // pVars->mfReflectionFadeStart = apVars->GetVarFloat("ReflectionFadeStart", 0);
-       // pVars->mfReflectionFadeEnd = apVars->GetVarFloat("ReflectionFadeEnd", 0);
-       // pVars->mfWaveSpeed = apVars->GetVarFloat("WaveSpeed", 1.0f);
-       // pVars->mfWaveAmplitude = apVars->GetVarFloat("WaveAmplitude", 1.0f);
-       // pVars->mfWaveFreq = apVars->GetVarFloat("WaveFreq", 1.0f);
-
-       // apMaterial->SetWorldReflectionOcclusionTest(apVars->GetVarBool("OcclusionCullWorldReflection", true));
-       // apMaterial->SetMaxReflectionDistance(apVars->GetVarFloat("ReflectionFadeEnd", 0.0f));
-       // apMaterial->SetLargeTransperantSurface(apVars->GetVarBool("LargeSurface", false));
     }
 
     void cMaterialType_Water::GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars) {
-       // cMaterialType_Water_Vars* pVars = (cMaterialType_Water_Vars*)apMaterial->GetVars();
-
-       // apVars->AddVarBool("HasReflection", pVars->mbHasReflection);
-       // apVars->AddVarFloat("RefractionScale", pVars->mfRefractionScale);
-       // apVars->AddVarFloat("FrenselBias", pVars->mfFrenselBias);
-       // apVars->AddVarFloat("FrenselPow", pVars->mfFrenselPow);
-       // apVars->AddVarFloat("ReflectionFadeStart", pVars->mfReflectionFadeStart);
-       // apVars->AddVarFloat("ReflectionFadeEnd", pVars->mfReflectionFadeEnd);
-       // apVars->AddVarFloat("WaveSpeed", pVars->mfWaveSpeed);
-       // apVars->AddVarFloat("WaveAmplitude", pVars->mfWaveAmplitude);
-       // apVars->AddVarFloat("WaveFreq", pVars->mfWaveFreq);
-
-       // apVars->AddVarBool("OcclusionCullWorldReflection", apMaterial->GetWorldReflectionOcclusionTest());
-       // apVars->AddVarBool("LargeSurface", apMaterial->GetLargeTransperantSurface());
     }
 
     void cMaterialType_Water::CompileMaterialSpecifics(cMaterial* apMaterial) {
-        //cMaterialType_Water_Vars* pVars = static_cast<cMaterialType_Water_Vars*>(apMaterial->GetVars());
-
-       // /////////////////////////////////////
-       // // Set if has specific variables
-       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_Diffuse, true);
-       // apMaterial->SetHasSpecificSettings(eMaterialRenderMode_DiffuseFog, true);
-
-        /////////////////////////////////////
-        // Set up the blend mode
-       // if (iRenderer::GetRefractionEnabled()) {
-       //     apMaterial->SetBlendMode(eMaterialBlendMode_None);
-       // } else {
-       //     apMaterial->SetBlendMode(eMaterialBlendMode_Mul);
-       // }
-
-       // /////////////////////////////////////
-       // // Set up the refraction
-       // if (iRenderer::GetRefractionEnabled()) {
-       //     apMaterial->SetHasRefraction(true);
-       //     apMaterial->SetUseRefractionEdgeCheck(true);
-       // }
-
-       // ///////////////////////////
-       // // Set up reflection
-       // if (pVars->mbHasReflection && iRenderer::GetRefractionEnabled()) {
-       //     if (apMaterial->GetImage(eMaterialTexture_CubeMap) == NULL) {
-       //         apMaterial->SetHasWorldReflection(true);
-       //     }
-       // }
     }
 
 } // namespace hpl

--- a/HPL2/sources/graphics/RenderList.cpp
+++ b/HPL2/sources/graphics/RenderList.cpp
@@ -327,10 +327,7 @@ namespace hpl {
         ////////////////////////////////////////
         // Update material, if not already done this frame
         cMaterial* pMaterial = apObject->GetMaterial();
-        auto metaInfoIt = pMaterial ? std::find_if(cMaterial::MaterialMetaTable.begin(), cMaterial::MaterialMetaTable.end(), [&](auto& info) {
-            return info.m_id == pMaterial->type().m_id;
-        }) : std::end(cMaterial::MaterialMetaTable);
-
+        const bool isValidMaterial = pMaterial && pMaterial->Descriptor().m_id != MaterialID::Unknown;
         if (pMaterial && pMaterial->GetRenderFrameCount() != iRenderer::GetRenderFrameCount()) {
             pMaterial->SetRenderFrameCount(iRenderer::GetRenderFrameCount());
             pMaterial->UpdateBeforeRendering(m_frameTime);
@@ -346,7 +343,7 @@ namespace hpl {
         ////////////////////////////////////////
         // Update per viewport specific and set amtrix point
         // Skip this for non-decal translucent! This is because the water rendering might mess it up otherwise!
-        if (metaInfoIt == std::end(cMaterial::MaterialMetaTable) || metaInfoIt->m_isTranslucent == false || metaInfoIt->m_isDecal) {
+        if (!isValidMaterial || !cMaterial::IsTranslucent(pMaterial->Descriptor().m_id) || pMaterial->Descriptor().m_id == MaterialID::Decal) {
             // skip rendering if the update return false
             if (apObject->UpdateGraphicsForViewport(m_frustum, m_frameTime) == false) {
                 return;
@@ -362,7 +359,7 @@ namespace hpl {
         ////////////////////////////////////////
         // Calculate the View Z value
         //  For transparent and non decals!
-        if (metaInfoIt != std::end(cMaterial::MaterialMetaTable) && metaInfoIt->m_isTranslucent && metaInfoIt->m_isDecal == false) {
+        if (isValidMaterial && cMaterial::IsTranslucent(pMaterial->Descriptor().m_id) && pMaterial->Descriptor().m_id != MaterialID::Decal) {
             cVector3f vIntersectionPos;
             cBoundingVolume* pBV = apObject->GetBoundingVolume();
 
@@ -408,9 +405,8 @@ namespace hpl {
 
             ////////////////////////
             // Transparent
-            ASSERT(metaInfoIt != std::end(cMaterial::MaterialMetaTable));
-            if (metaInfoIt->m_isTranslucent) {
-                if (metaInfoIt->m_isDecal) {
+            if (cMaterial::IsTranslucent(pMaterial->Descriptor().m_id)) {
+                if (pMaterial->Descriptor().m_id == MaterialID::Decal) {
                     m_decalObjects.push_back(apObject);
                 } else {
                     m_transObjects.push_back(apObject);

--- a/HPL2/sources/graphics/RendererDeferred.cpp
+++ b/HPL2/sources/graphics/RendererDeferred.cpp
@@ -212,7 +212,7 @@ namespace hpl {
                 for (auto& object : apNode->GetObjects()) {
                     // Check so visible and shadow caster
                     if (rendering::detail::IsObjectIsVisible(object, eRenderableFlag_ShadowCaster, clipPlanes) == false ||
-                        object->GetMaterial() == NULL || object->GetMaterial()->GetType()->IsTranslucent()) {
+                        object->GetMaterial() == NULL || cMaterial::IsTranslucent(object->GetMaterial()->Descriptor().m_id)) {
                         continue;
                     }
 
@@ -564,7 +564,7 @@ namespace hpl {
             desc.mDesc.mFlags = BUFFER_CREATION_FLAG_PERSISTENT_MAP_BIT;
             desc.mDesc.mFirstElement = 0;
             desc.mDesc.mElementCount = cMaterial::MaxMaterialID;
-            desc.mDesc.mStructStride = sizeof(cMaterial::MaterialType::MaterialData);
+            desc.mDesc.mStructStride = sizeof(material::UniformMaterialBlock);
             desc.mDesc.mSize = desc.mDesc.mElementCount * desc.mDesc.mStructStride;
             desc.ppBuffer = buffer;
             addResource(&desc, nullptr);
@@ -2504,7 +2504,7 @@ namespace hpl {
             if (pMaterial == nullptr || vertexBuffer == nullptr) {
                 continue;
             }
-            ASSERT(pMaterial->type().m_id == MaterialID::SolidDiffuse && "Invalid material type");
+            ASSERT(pMaterial->Descriptor().m_id == MaterialID::SolidDiffuse && "Invalid material type");
             MaterialRootConstant materialConst = {};
             uint32_t instance = cmdBindMaterialAndObject(cmd, frame, pMaterial, illuminationItem);
             materialConst.objectId = instance;
@@ -2743,9 +2743,9 @@ namespace hpl {
                                     eMaterialRenderMode renderMode =
                                         pObject->GetCoverageAmount() >= 1 ? eMaterialRenderMode_Z : eMaterialRenderMode_Z_Dissolve;
                                     cMaterial* pMaterial = pObject->GetMaterial();
-                                    iMaterialType* materialType = pMaterial->GetType();
+                                    const MaterialDescriptor& descriptor = pMaterial->Descriptor();
                                     iVertexBuffer* vertexBuffer = pObject->GetVertexBuffer();
-                                    if (vertexBuffer == nullptr || materialType == nullptr) {
+                                    if (vertexBuffer == nullptr || descriptor.m_id == MaterialID::Unknown) {
                                         return;
                                     }
                                     MaterialRootConstant materialConst = {};
@@ -3148,7 +3148,7 @@ namespace hpl {
                     continue;
                 }
 
-                ASSERT(pMaterial->type().m_id == MaterialID::SolidDiffuse && "Invalid material type");
+                ASSERT(pMaterial->Descriptor().m_id == MaterialID::SolidDiffuse && "Invalid material type");
                 MaterialRootConstant materialConst = {};
                 uint32_t instance = cmdBindMaterialAndObject(cmd, frame, pMaterial, diffuseItem);
                 materialConst.objectId = instance;
@@ -3188,7 +3188,7 @@ namespace hpl {
                     continue;
                 }
                 ASSERT(pMaterial->GetBlendMode() < eMaterialBlendMode_LastEnum && "Invalid blend mode");
-                ASSERT(pMaterial->type().m_id == MaterialID::Decal && "Invalid material type");
+                ASSERT(pMaterial->Descriptor().m_id == MaterialID::Decal && "Invalid material type");
                 cmdBindPipeline(cmd, options.m_invert ? m_decalPipelineCW[pMaterial->GetBlendMode()].m_handle : m_decalPipeline[pMaterial->GetBlendMode()].m_handle);
 
                 std::array targets = { eVertexBufferElement_Position, eVertexBufferElement_Texture0, eVertexBufferElement_Color0 };
@@ -3298,7 +3298,7 @@ namespace hpl {
                     ////////////////////////////////////////
                     // Update per viewport specific and set amtrix point
                     // Skip this for non-decal translucent! This is because the water rendering might mess it up otherwise!
-                    if (pMaterial == NULL || pMaterial->GetType()->IsTranslucent() == false || pMaterial->GetType()->IsDecal()) {
+                    if (pMaterial == NULL || cMaterial::IsTranslucent(pMaterial->Descriptor().m_id) == false || pMaterial->Descriptor().m_id == MaterialID::Decal) {
                         // skip rendering if the update return false
                         if (pObject->UpdateGraphicsForViewport(apFrustum, frameTime) == false) {
                             return;
@@ -3396,7 +3396,7 @@ namespace hpl {
                 reinterpret_cast<float4*>(updateDesc.pMappedData)[1] = float4(boundBoxMax.x, boundBoxMax.y, boundBoxMax.z, 0.0f);
                 endUpdateResource(&updateDesc, nullptr);
 
-                if (!test.m_preZPass || !vertexBuffer || !pMaterial || pMaterial->GetType()->IsTranslucent()) {
+                if (!test.m_preZPass || !vertexBuffer || !pMaterial || cMaterial::IsTranslucent(pMaterial->Descriptor().m_id)) {
                     continue;
                 }
 
@@ -3636,7 +3636,7 @@ namespace hpl {
 
                     cMaterial* pMaterial = renderable->GetMaterial();
                     iVertexBuffer* vertexBuffer = renderable->GetVertexBuffer();
-                    if (!vertexBuffer || !pMaterial || pMaterial->GetType()->IsTranslucent()) {
+                    if (!vertexBuffer || !pMaterial || cMaterial::IsTranslucent(pMaterial->Descriptor().m_id)) {
                         continue;
                     }
 
@@ -3668,22 +3668,21 @@ namespace hpl {
 
         auto* objectDescSet = m_materialSet.m_perObjectSet[frame.m_frameIndex].m_handle;
         auto objectLookup = m_materialSet.m_objectDescriptorLookup.find(apObject);
-        auto& info = m_materialSet.m_materialInfo[apMaterial->materialID()];
+        auto& info = m_materialSet.m_materialInfo[apMaterial->Index()];
         auto& descInfo = info.m_materialDescInfo[frame.m_frameIndex];
-        auto& materialType = apMaterial->type();
         auto& materialDesc = apMaterial->Descriptor();
 
 
         auto metaInfo = std::find_if(cMaterial::MaterialMetaTable.begin(), cMaterial::MaterialMetaTable.end(), [&](auto& info) {
-            return info.m_id == materialType.m_id;
+            return info.m_id == materialDesc.m_id;
         });
 
-        if (descInfo.m_material != apMaterial || descInfo.m_version != apMaterial->Version()) {
-            descInfo.m_version = apMaterial->Version();
+        if (descInfo.m_material != apMaterial || descInfo.m_version != apMaterial->Generation()) {
+            descInfo.m_version = apMaterial->Generation();
             descInfo.m_material = apMaterial;
 
             BufferUpdateDesc updateDesc = { m_materialSet.m_materialUniformBuffer.m_handle,
-                                            apMaterial->materialID() * sizeof(cMaterial::MaterialType::MaterialData) };
+                                            apMaterial->Index() * sizeof(hpl::material::UniformMaterialBlock) };
             beginUpdateResource(&updateDesc);
             (*reinterpret_cast<material::UniformMaterialBlock*>(updateDesc.pMappedData)) = material::UniformMaterialBlock::CreateFromMaterial(*apMaterial);
             endUpdateResource(&updateDesc, NULL);
@@ -3713,7 +3712,7 @@ namespace hpl {
             }
             updateDescriptorSet(
                 frame.m_renderer->Rend(),
-                apMaterial->materialID(),
+                apMaterial->Index(),
                 m_materialSet.m_perBatchSet[frame.m_frameIndex].m_handle,
                 paramCount,
                 params.data());
@@ -3726,7 +3725,7 @@ namespace hpl {
 
             cRendererDeferred::UniformObject uniformObjectData = {};
             uniformObjectData.m_dissolveAmount = apObject->GetCoverageAmount();
-            uniformObjectData.m_materialIndex = apMaterial->materialID();
+            uniformObjectData.m_materialIndex = apMaterial->Index();
             uniformObjectData.m_modelMat = cMath::ToForgeMat4(modelMat.GetTranspose());
             uniformObjectData.m_invModelMat = cMath::ToForgeMat4(cMath::MatrixInverse(modelMat).GetTranspose());
             if (apMaterial) {
@@ -3745,7 +3744,7 @@ namespace hpl {
             cmd,
             detail::resolveMaterialID(apMaterial->GetTextureAntistropy(), apMaterial->GetTextureWrap(), apMaterial->GetTextureFilter()),
             m_materialSet.m_materialConstSet.m_handle);
-        cmdBindDescriptorSet(cmd, apMaterial->materialID(), m_materialSet.m_perBatchSet[frame.m_frameIndex].m_handle);
+        cmdBindDescriptorSet(cmd, apMaterial->Index(), m_materialSet.m_perBatchSet[frame.m_frameIndex].m_handle);
         return index;
     }
 
@@ -4073,7 +4072,7 @@ void cRendererDeferred::Draw(
             if (pMaterial == nullptr || vertexBuffer == nullptr) {
                 continue;
             }
-            ASSERT(pMaterial->type().m_id == MaterialID::SolidDiffuse && "Invalid material type");
+            ASSERT(pMaterial->Descriptor().m_id == MaterialID::SolidDiffuse && "Invalid material type");
             MaterialRootConstant materialConst = {};
             uint32_t instance = cmdBindMaterialAndObject(frame.m_cmd, frame, pMaterial, illuminationItem);
             materialConst.objectId = instance;
@@ -4308,7 +4307,7 @@ void cRendererDeferred::Draw(
             const bool isRefraction = iRenderer::GetRefractionEnabled() && pMaterial->HasRefraction();
             const bool isReflection = pMaterial->HasWorldReflection() && translucencyItem->GetRenderType() == eRenderableType_SubMesh &&
                 mpCurrentSettings->mbRenderWorldReflection;
-            const bool isFogActive = mpCurrentWorld->GetFogActive() && pMaterial->GetAffectedByFog();
+            const bool isFogActive = mpCurrentWorld->GetFogActive();
             const bool isParticleEmitter = TypeInfo<iParticleEmitter>::IsSubtype(*translucencyItem);
             const auto cubeMap = pMaterial->GetImage(eMaterialTexture_CubeMap);
             uint32_t reflectionBufferIndex = 0;
@@ -4536,10 +4535,8 @@ void cRendererDeferred::Draw(
 
             MaterialRootConstant materialConst = { 0 };
             float sceneAlpha = 1;
-            if (pMaterial->GetAffectedByFog()) {
-                for (auto& fogArea : fogRenderData) {
-                    sceneAlpha *= detail::GetFogAreaVisibilityForObject(fogArea, *apFrustum, translucencyItem);
-                }
+            for (auto& fogArea : fogRenderData) {
+                sceneAlpha *= detail::GetFogAreaVisibilityForObject(fogArea, *apFrustum, translucencyItem);
             }
             materialConst.m_sceneAlpha = sceneAlpha;
             materialConst.m_lightLevel = 1.0f;
@@ -4574,7 +4571,7 @@ void cRendererDeferred::Draw(
             }
             materialConst.m_afT = GetTimeCount();
 
-            switch (pMaterial->type().m_id) {
+            switch (pMaterial->Descriptor().m_id) {
             case MaterialID::Translucent:
                 {
                     uint32_t instance = cmdBindMaterialAndObject(
@@ -4646,7 +4643,7 @@ void cRendererDeferred::Draw(
                     materialConst.m_options = (isFogActive ? TranslucencyFlags::UseFog : 0) |
                         (isRefraction ? TranslucencyFlags::UseRefractionTrans : 0) |
                         (isReflection ? TranslucencyFlags::UseReflectionTrans : 0) |
-                        translucencyBlendTable[pMaterial->GetBlendMode()] |
+                        (isRefraction ? translucencyBlendTable[eMaterialBlendMode_None]: translucencyBlendTable[eMaterialBlendMode_Mul]) |
                         (((reflectionBufferIndex & TranslucencyReflectionBufferMask) << TranslucencyReflectionBufferOffset));
 
 

--- a/HPL2/sources/resources/MaterialManager.cpp
+++ b/HPL2/sources/resources/MaterialManager.cpp
@@ -22,18 +22,18 @@
 #include "graphics/Image.h"
 #include "graphics/IndexPool.h"
 #include "system/LowLevelSystem.h"
+#include "system/Platform.h"
 #include "system/String.h"
 #include "system/System.h"
-#include "system/Platform.h"
 
 #include "graphics/Graphics.h"
+#include "graphics/LowLevelGraphics.h"
 #include "graphics/Material.h"
 #include "graphics/MaterialType.h"
-#include "graphics/LowLevelGraphics.h"
 
-#include "resources/TextureManager.h"
-#include "resources/Resources.h"
 #include "resources/LowLevelResources.h"
+#include "resources/Resources.h"
+#include "resources/TextureManager.h"
 #include "resources/XmlDocument.h"
 
 #include "impl/tinyXML/tinyxml.h"
@@ -43,578 +43,572 @@
 
 namespace hpl {
 
-	namespace internal {
+    namespace internal {
         static IndexPool m_MaterialIndexPool(cMaterial::MaxMaterialID);
     }
 
-	class cMaterialManagerBlankMaterialType_Vars : public iMaterialVars
-	{
-	};
+    class cMaterialManagerBlankMaterialType_Vars : public iMaterialVars {};
 
-	class cMaterialManagerBlankMaterialType : public iMaterialType
-	{
-	public:
-		cMaterialManagerBlankMaterialType() : iMaterialType(NULL, NULL){}
+    class cMaterialManagerBlankMaterialType : public iMaterialType {
+    public:
+        cMaterialManagerBlankMaterialType()
+            : iMaterialType(NULL, NULL) {
+        }
 
-		void LoadData() override{}
-		void DestroyData() override{}
+        void LoadData() override {
+        }
+        void DestroyData() override {
+        }
 
-		iMaterialVars* CreateSpecificVariables() override { return hplNew(cMaterialManagerBlankMaterialType_Vars,());}
-		void LoadVariables(cMaterial *apMaterial, cResourceVarsObject *apVars) override{ }
-		void GetVariableValues(cMaterial *apMaterial, cResourceVarsObject *apVars) override{ }
+        iMaterialVars* CreateSpecificVariables() override {
+            return hplNew(cMaterialManagerBlankMaterialType_Vars, ());
+        }
+        void LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars) override {
+        }
+        void GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars) override {
+        }
 
-		void CompileMaterialSpecifics(cMaterial *apMaterial){}
-	};
+        void CompileMaterialSpecifics(cMaterial* apMaterial) {
+        }
+    };
 
-	cMaterialManagerBlankMaterialType gBlankMaterialType;
-	cMaterialManager::cMaterialManager(cGraphics* apGraphics,cResources *apResources)
-		: iResourceManager(apResources->GetFileSearcher(), apResources->GetLowLevel(),apResources->GetLowLevelSystem())
-	{
-		mpGraphics = apGraphics;
-		mpResources = apResources;
+    cMaterialManagerBlankMaterialType gBlankMaterialType;
+    cMaterialManager::cMaterialManager(cGraphics* apGraphics, cResources* apResources)
+        : iResourceManager(apResources->GetFileSearcher(), apResources->GetLowLevel(), apResources->GetLowLevelSystem()) {
+        mpGraphics = apGraphics;
+        mpResources = apResources;
 
-		mlTextureSizeDownScaleLevel =0;
-		mTextureFilter = eTextureFilter_Bilinear;
-		mfTextureAnisotropy = 1.0f;
+        mlTextureSizeDownScaleLevel = 0;
+        mTextureFilter = eTextureFilter_Bilinear;
+        mfTextureAnisotropy = 1.0f;
 
-		mbDisableRenderDataLoading = false;
+        mbDisableRenderDataLoading = false;
 
-		mlIdCounter =0;
-	}
+        mlIdCounter = 0;
+    }
 
-	cMaterialManager::~cMaterialManager()
-	{
+    cMaterialManager::~cMaterialManager() {
         DestroyAll();
 
-		Log(" Done with materials\n");
-	}
+        Log(" Done with materials\n");
+    }
 
-	cMaterial* cMaterialManager::CreateMaterial(const tString& asName)
-	{
-		if(asName=="")
-			return NULL;
+    cMaterial* cMaterialManager::CreateMaterial(const tString& asName) {
+        if (asName == "")
+            return NULL;
 
-		tWString sPath;
-		cMaterial* pMaterial;
-		tString asNewName;
+        tWString sPath;
+        cMaterial* pMaterial;
+        tString asNewName;
 
-		BeginLoad(asName);
+        BeginLoad(asName);
 
-		asNewName = cString::SetFileExt(asName,"mat");
+        asNewName = cString::SetFileExt(asName, "mat");
 
-		pMaterial = static_cast<cMaterial*>(this->FindLoadedResource(asNewName,sPath));
+        pMaterial = static_cast<cMaterial*>(this->FindLoadedResource(asNewName, sPath));
 
-		if(pMaterial==NULL && sPath!=_W(""))
-		{
-			pMaterial = LoadFromFile(asNewName,sPath);
+        if (pMaterial == NULL && sPath != _W("")) {
+            pMaterial = LoadFromFile(asNewName, sPath);
 
-			if(pMaterial==NULL){
-				Error("Couldn't load material '%s'\n",asNewName.c_str());
-				EndLoad();
-				return NULL;
-			}
+            if (pMaterial == NULL) {
+                Error("Couldn't load material '%s'\n", asNewName.c_str());
+                EndLoad();
+                return NULL;
+            }
 
-			AddResource(pMaterial);
-		}
+            AddResource(pMaterial);
+        }
 
-		if(pMaterial)pMaterial->IncUserCount();
-		else Error("Couldn't create material '%s'\n",asNewName.c_str());
+        if (pMaterial)
+            pMaterial->IncUserCount();
+        else
+            Error("Couldn't create material '%s'\n", asNewName.c_str());
 
-		EndLoad();
-		return pMaterial;
-	}
+        EndLoad();
+        return pMaterial;
+    }
 
-	void cMaterialManager::Update(float afTimeStep)
-	{
+    void cMaterialManager::Update(float afTimeStep) {
+    }
 
-	}
+    void cMaterialManager::Unload(iResourceBase* apResource) {
+    }
 
-	void cMaterialManager::Unload(iResourceBase* apResource)
-	{
+    void cMaterialManager::Destroy(iResourceBase* apResource) {
+        apResource->DecUserCount();
 
-	}
+        if (apResource->HasUsers() == false) {
+            RemoveResource(apResource);
+            hplDelete(apResource);
+        }
+    }
 
-	void cMaterialManager::Destroy(iResourceBase* apResource)
-	{
-		apResource->DecUserCount();
+    void cMaterialManager::SetTextureFilter(eTextureFilter aFilter) {
+        if (aFilter == mTextureFilter)
+            return;
+        mTextureFilter = aFilter;
 
-		if(apResource->HasUsers()==false)
-		{
-			RemoveResource(apResource);
-			hplDelete(apResource);
-		}
-	}
+        tResourceBaseMapIt it = m_mapResources.begin();
+        for (; it != m_mapResources.end(); ++it) {
+            cMaterial* pMat = static_cast<cMaterial*>(it->second);
+            pMat->setTextureFilter(aFilter);
+        }
+    }
 
-	void cMaterialManager::SetTextureFilter(eTextureFilter aFilter)
-	{
-		if(aFilter == mTextureFilter) return;
-		mTextureFilter = aFilter;
+    void cMaterialManager::SetTextureAnisotropy(float afX) {
+        if (mfTextureAnisotropy == afX)
+            return;
+        mfTextureAnisotropy = afX;
 
-		tResourceBaseMapIt it = m_mapResources.begin();
-		for(; it != m_mapResources.end(); ++it)
-		{
-			cMaterial *pMat = static_cast<cMaterial*>(it->second);
-		    pMat->setTextureFilter(aFilter);
-		}
-	}
-
-	void cMaterialManager::SetTextureAnisotropy(float afX)
-	{
-
-		if(mfTextureAnisotropy == afX) return;
-		mfTextureAnisotropy = afX;
-
-		tResourceBaseMapIt it = m_mapResources.begin();
-		for(; it != m_mapResources.end(); ++it)
-		{
-			cMaterial *pMat = static_cast<cMaterial*>(it->second);
+        tResourceBaseMapIt it = m_mapResources.begin();
+        for (; it != m_mapResources.end(); ++it) {
+            cMaterial* pMat = static_cast<cMaterial*>(it->second);
             pMat->SetTextureAnisotropy(afX);
+        }
+    }
 
-		}
-	}
+    tString cMaterialManager::GetPhysicsMaterialName(const tString& asName) {
+        tWString sPath;
+        cMaterial* pMaterial;
+        tString asNewName;
 
-	tString cMaterialManager::GetPhysicsMaterialName(const tString& asName)
-	{
-		tWString sPath;
-		cMaterial* pMaterial;
-		tString asNewName;
+        asNewName = cString::SetFileExt(asName, "mat");
 
-		asNewName = cString::SetFileExt(asName,"mat");
+        pMaterial = static_cast<cMaterial*>(this->FindLoadedResource(asNewName, sPath));
 
-		pMaterial = static_cast<cMaterial*>(this->FindLoadedResource(asNewName,sPath));
+        if (pMaterial == NULL && sPath != _W("")) {
+            FILE* pFile = cPlatform::OpenFile(sPath, _W("rb"));
+            if (pFile == NULL)
+                return "";
 
-		if(pMaterial==NULL && sPath!=_W(""))
-		{
-			FILE *pFile = cPlatform::OpenFile(sPath, _W("rb"));
-			if(pFile==NULL) return "";
+            TiXmlDocument* pDoc = hplNew(TiXmlDocument, ());
+            if (!pDoc->LoadFile(pFile)) {
+                fclose(pFile);
+                hplDelete(pDoc);
+                return "";
+            }
+            fclose(pFile);
 
-			TiXmlDocument *pDoc = hplNew( TiXmlDocument, () );
-			if(!pDoc->LoadFile(pFile))
-			{
-				fclose(pFile);
-				hplDelete(pDoc);
-				return "";
-			}
-			fclose(pFile);
+            TiXmlElement* pRoot = pDoc->RootElement();
 
-			TiXmlElement *pRoot = pDoc->RootElement();
+            TiXmlElement* pMain = pRoot->FirstChildElement("Main");
+            if (pMain == NULL) {
+                hplDelete(pDoc);
+                Error("Main child not found in '%s'\n", sPath.c_str());
+                return "";
+            }
 
-			TiXmlElement *pMain = pRoot->FirstChildElement("Main");
-			if(pMain==NULL){
-				hplDelete(pDoc);
-				Error("Main child not found in '%s'\n",sPath.c_str());
-				return "";
-			}
+            tString sPhysicsName = cString::ToString(pMain->Attribute("PhysicsMaterial"), "Default");
 
-			tString sPhysicsName = cString::ToString(pMain->Attribute("PhysicsMaterial"),"Default");
+            hplDelete(pDoc);
 
-			hplDelete(pDoc);
+            return sPhysicsName;
+        }
 
-			return sPhysicsName;
-		}
+        if (pMaterial)
+            return pMaterial->GetPhysicsMaterial();
+        else
+            return "";
+    }
 
-		if(pMaterial)
-			return pMaterial->GetPhysicsMaterial();
-		else
-			return "";
-	}
+    //-----------------------------------------------------------------------
 
-	//-----------------------------------------------------------------------
+    cMaterial* cMaterialManager::CreateCustomMaterial(const tString& asName, iMaterialType* apMaterialType) {
+        cMaterial* pMat = hplNew(cMaterial, (asName, cString::To16Char(asName), mpGraphics, mpResources));
+        pMat->IncUserCount();
+        AddResource(pMat);
+        return pMat;
+    }
 
-	cMaterial* cMaterialManager::CreateCustomMaterial(const tString& asName, iMaterialType *apMaterialType)
-	{
-		cMaterial* pMat = hplNew( cMaterial, (asName, cString::To16Char(asName), mpGraphics, mpResources, apMaterialType) );
-		pMat->IncUserCount();
-		AddResource(pMat);
-		return pMat;
-	}
+    cMaterial* cMaterialManager::LoadFromFile(const tString& asName, const tWString& asPath) {
+        iXmlDocument* pDoc = mpResources->GetLowLevel()->CreateXmlDocument();
+        if (pDoc->CreateFromFile(asPath) == false) {
+            mpResources->DestroyXmlDocument(pDoc);
+            return NULL;
+        }
 
-	cMaterial* cMaterialManager::LoadFromFile(const tString& asName,const tWString& asPath)
-	{
-		iXmlDocument* pDoc = mpResources->GetLowLevel()->CreateXmlDocument();
-		if(pDoc->CreateFromFile(asPath)==false)
-		{
-			mpResources->DestroyXmlDocument(pDoc);
-			return NULL;
-		}
+        cXmlElement* pMain = pDoc->GetFirstElement("Main");
+        if (pMain == NULL) {
+            mpResources->DestroyXmlDocument(pDoc);
+            Error("Main child not found.\n");
+            return NULL;
+        }
 
-		cXmlElement* pMain = pDoc->GetFirstElement("Main");
-		if(pMain==NULL)
-		{
-			mpResources->DestroyXmlDocument(pDoc);
-			Error("Main child not found.\n");
-			return NULL;
-		}
+        tString sType = pMain->GetAttributeString("Type");
+        if (sType == "") {
+            mpResources->DestroyXmlDocument(pDoc);
+            Error("Type not found.\n");
+            return NULL;
+        }
 
-		tString sType = pMain->GetAttributeString("Type");
-		if(sType=="")
-		{
-			mpResources->DestroyXmlDocument(pDoc);
-			Error("Type not found.\n");
-			return NULL;
-		}
+        /////////////////////////////
+        // Get General Propertries
+        bool bDepthTest = pMain->GetAttributeBool("DepthTest", true);
+        float fValue = pMain->GetAttributeFloat("Value", 1);
+        tString sPhysicsMatName = pMain->GetAttributeString("PhysicsMaterial", "Default");
+        tString sBlendMode = pMain->GetAttributeString("BlendMode", "Add");
 
-		/////////////////////////////
-		// Get General Propertries
-		bool bDepthTest = pMain->GetAttributeBool("DepthTest", true);
-		float fValue = pMain->GetAttributeFloat("Value", 1);
-		tString sPhysicsMatName = pMain->GetAttributeString("PhysicsMaterial", "Default");
-		tString sBlendMode = pMain->GetAttributeString("BlendMode", "Add");
+        /////////////////////////////
+        // Make a "fake" material, with a blank type
+        if (mbDisableRenderDataLoading) {
+            cMaterial* pMat = hplNew(cMaterial, (asName, asPath, mpGraphics, mpResources));
+            pMat->SetPhysicsMaterial(sPhysicsMatName);
 
-		/////////////////////////////
-		// Make a "fake" material, with a blank type
-		if(mbDisableRenderDataLoading)
-		{
-			cMaterial* pMat = hplNew( cMaterial, (asName, asPath, mpGraphics, mpResources, &gBlankMaterialType) );
-			pMat->SetPhysicsMaterial(sPhysicsMatName);
+            mpResources->DestroyXmlDocument(pDoc);
+            return pMat;
+        }
 
-			mpResources->DestroyXmlDocument(pDoc);
-			return pMat;
-		}
+        /////////////////////////////
+        // CreateType
+        tString normalizedMaterialName = cString::ToLowerCase(sType);
+        auto metaInfo = std::find_if(cMaterial::MaterialMetaTable.begin(), cMaterial::MaterialMetaTable.end(), [&](auto& info) {
+            return info.m_name == normalizedMaterialName;
+        });
 
-		/////////////////////////////
-		// CreateType
-		iMaterialType *pMatType = mpGraphics->GetMaterialType(sType);
-		tString normalizedMaterialName = cString::ToLowerCase(sType);
-	    auto metaInfo = std::find_if(cMaterial::MaterialMetaTable.begin(), cMaterial::MaterialMetaTable.end(), [&](auto& info) {
-	        return info.m_name == normalizedMaterialName;
-	    });
+        if (metaInfo == cMaterial::MaterialMetaTable.end()) {
+            mpResources->DestroyXmlDocument(pDoc);
+            LOGF(eERROR, "Invalid material type %s", sType.c_str());
+            return NULL;
+        }
+        cMaterial* pMat = new cMaterial(asName, asPath, mpGraphics, mpResources);
+        pMat->SetDepthTest(bDepthTest);
+        pMat->SetPhysicsMaterial(sPhysicsMatName);
 
-	    if(pMatType == NULL || metaInfo == cMaterial::MaterialMetaTable.end())
-		{
-			mpResources->DestroyXmlDocument(pDoc);
-			LOGF(eERROR, "Invalid material type %s", sType.c_str());
-			return NULL;
-		}
-		cMaterial* pMat = new cMaterial(asName, asPath, mpGraphics, mpResources, pMatType);
-		pMat->SetDepthTest(bDepthTest);
-		pMat->SetPhysicsMaterial(sPhysicsMatName);
-        if(metaInfo->m_isTranslucent) {
-			pMat->SetBlendMode(GetBlendMode(sBlendMode));
-		}
+        ///////////////////////////
+        // Textures
+        cXmlElement* pTexRoot = pDoc->GetFirstElement("TextureUnits");
+        if (pTexRoot == NULL) {
+            mpResources->DestroyXmlDocument(pDoc);
+            Error("TextureUnits child not found.\n");
+            return NULL;
+        }
 
-		///////////////////////////
-		//Textures
-		cXmlElement* pTexRoot = pDoc->GetFirstElement("TextureUnits");
-		if(pTexRoot==NULL){
-			mpResources->DestroyXmlDocument(pDoc);
-			Error("TextureUnits child not found.\n");
-			return NULL;
-		}
+        for (eMaterialTexture textureType : metaInfo->m_usedTextures) {
+            tString sTextureType = GetTextureString(textureType);
 
-	    for(eMaterialTexture textureType: metaInfo->m_usedTextures) {
-			tString sTextureType = GetTextureString(textureType);
+            cXmlElement* pTexChild = pTexRoot->GetFirstElement(sTextureType.c_str());
+            if (pTexChild == NULL) {
+                // Log(" Texture unit element missing!\n");
+                /*hplDelete(pMat);
+                return NULL;*/
+                continue;
+            }
 
-			cXmlElement* pTexChild = pTexRoot->GetFirstElement(sTextureType.c_str());
-			if(pTexChild==NULL){
-				//Log(" Texture unit element missing!\n");
-				/*hplDelete(pMat);
-				return NULL;*/
-				continue;
-			}
+            eTextureType type = GetType(pTexChild->GetAttributeString("Type", ""));
+            tString sFile = pTexChild->GetAttributeString("File", "");
+            bool bMipMaps = pTexChild->GetAttributeBool("MipMaps", true);
+            bool bCompress = pTexChild->GetAttributeBool("Compress", false);
+            eTextureWrap wrap = GetWrap(pTexChild->GetAttributeString("Wrap", ""));
 
-			eTextureType type = GetType(pTexChild->GetAttributeString("Type", ""));
-			tString sFile = pTexChild->GetAttributeString("File", "");
-			bool bMipMaps = pTexChild->GetAttributeBool("MipMaps", true);
-			bool bCompress = pTexChild->GetAttributeBool("Compress", false);
-			eTextureWrap wrap = GetWrap(pTexChild->GetAttributeString("Wrap", ""));
+            eTextureAnimMode animMode = GetAnimMode(pTexChild->GetAttributeString("AnimMode", "None"));
+            float fFrameTime = pTexChild->GetAttributeFloat("AnimFrameTime", 1.0f);
 
-			eTextureAnimMode animMode = GetAnimMode(pTexChild->GetAttributeString("AnimMode", "None"));
-			float fFrameTime = pTexChild->GetAttributeFloat("AnimFrameTime", 1.0f);
+            if (sFile == "")
+                continue;
 
-			if(sFile=="") continue;
+            if (cString::GetFilePath(sFile).length() <= 1) {
+                sFile = cString::SetFilePath(sFile, cString::To8Char(cString::GetFilePathW(asPath)));
+            }
 
-			if(cString::GetFilePath(sFile).length() <= 1) {
-				sFile = cString::SetFilePath(sFile, cString::To8Char(cString::GetFilePathW(asPath)));
-			}
+            cTextureManager::ImageOptions options;
+            iResourceBase* pImageResource = nullptr;
+            if (animMode != eTextureAnimMode_None) {
+                auto animatedImage = mpResources->GetTextureManager()->CreateAnimImage(
+                    sFile, bMipMaps, type, eTextureUsage_Normal, mlTextureSizeDownScaleLevel);
+                animatedImage->SetFrameTime(fFrameTime);
+                animatedImage->SetAnimMode(animMode);
+                pMat->SetImage(textureType, animatedImage);
+                pImageResource = animatedImage;
 
-			cTextureManager::ImageOptions options;
-			iResourceBase* pImageResource = nullptr;
-			if(animMode != eTextureAnimMode_None)
-			{
-				auto animatedImage = mpResources->GetTextureManager()->CreateAnimImage(sFile,bMipMaps,type,eTextureUsage_Normal,mlTextureSizeDownScaleLevel);
-				animatedImage->SetFrameTime(fFrameTime);
-				animatedImage->SetAnimMode(animMode);
-				pMat->SetImage(textureType, animatedImage);
-				pImageResource = animatedImage;
-
-			}
-			else
-			{
-				Image* pImage = nullptr;
-				switch(type) {
-					case eTextureType_1D:
-						pImage = mpResources->GetTextureManager()->Create1DImage(sFile,bMipMaps,
-																				eTextureUsage_Normal,
-																				mlTextureSizeDownScaleLevel);
-						break;
-					case eTextureType_2D:
-						pImage = mpResources->GetTextureManager()->Create2DImage(sFile,bMipMaps, eTextureType_2D,
-																			eTextureUsage_Normal,
-																			mlTextureSizeDownScaleLevel);
-						break;
-					case eTextureType_CubeMap:
-						pImage = mpResources->GetTextureManager()->CreateCubeMapImage(sFile,bMipMaps,
-																			eTextureUsage_Normal,
-																			mlTextureSizeDownScaleLevel);
-						break;
-					case eTextureType_3D:
-						pImage = mpResources->GetTextureManager()->Create3DImage(sFile,bMipMaps,
-																		eTextureUsage_Normal,
-																		mlTextureSizeDownScaleLevel);
-						break;
-					default: {
-						ASSERT(false && "Invalid texture type");
-						break;
-					}
-				}
-				pImageResource = pImage;
-
-			    pMat->setTextureWrap(wrap);
-			    pMat->setTextureFilter(mTextureFilter);
-			    pMat->SetTextureAnisotropy(mfTextureAnisotropy);
-		        if(pImage) {
-					pMat->SetImage(textureType, pImage);
+            } else {
+                Image* pImage = nullptr;
+                switch (type) {
+                case eTextureType_1D:
+                    pImage =
+                        mpResources->GetTextureManager()->Create1DImage(sFile, bMipMaps, eTextureUsage_Normal, mlTextureSizeDownScaleLevel);
+                    break;
+                case eTextureType_2D:
+                    pImage = mpResources->GetTextureManager()->Create2DImage(
+                        sFile, bMipMaps, eTextureType_2D, eTextureUsage_Normal, mlTextureSizeDownScaleLevel);
+                    break;
+                case eTextureType_CubeMap:
+                    pImage = mpResources->GetTextureManager()->CreateCubeMapImage(
+                        sFile, bMipMaps, eTextureUsage_Normal, mlTextureSizeDownScaleLevel);
+                    break;
+                case eTextureType_3D:
+                    pImage =
+                        mpResources->GetTextureManager()->Create3DImage(sFile, bMipMaps, eTextureUsage_Normal, mlTextureSizeDownScaleLevel);
+                    break;
+                default:
+                    {
+                        ASSERT(false && "Invalid texture type");
+                        break;
+                    }
                 }
-			}
-			if(!pImageResource)
-			{
-				mpResources->DestroyXmlDocument(pDoc);
-				hplDelete(pMat);
-				return nullptr;
-			}
-	    }
+                pImageResource = pImage;
 
-		///////////////////////////
-		//Animations
-		cXmlElement* pUvAnimRoot = pDoc->GetFirstElement("UvAnimations");
-		if(pUvAnimRoot)
-		{
-			cXmlNodeListIterator it = pUvAnimRoot->GetChildIterator();
-			while(it.HasNext())
-			{
-				cXmlElement* pAnimElem = it.Next()->ToElement();
+                pMat->setTextureWrap(wrap);
+                pMat->setTextureFilter(mTextureFilter);
+                pMat->SetTextureAnisotropy(mfTextureAnisotropy);
+                if (pImage) {
+                    pMat->SetImage(textureType, pImage);
+                }
+            }
+            if (!pImageResource) {
+                mpResources->DestroyXmlDocument(pDoc);
+                hplDelete(pMat);
+                return nullptr;
+            }
+        }
 
-				eMaterialUvAnimation animType = GetUvAnimType(pAnimElem->GetAttributeString("Type").c_str());
-				eMaterialAnimationAxis animAxis = GetAnimAxis(pAnimElem->GetAttributeString("Axis").c_str());
-				float fSpeed = pAnimElem->GetAttributeFloat("Speed",0);
-				float fAmp = pAnimElem->GetAttributeFloat("Amplitude",0);
+        ///////////////////////////
+        // Animations
+        cXmlElement* pUvAnimRoot = pDoc->GetFirstElement("UvAnimations");
+        if (pUvAnimRoot) {
+            cXmlNodeListIterator it = pUvAnimRoot->GetChildIterator();
+            while (it.HasNext()) {
+                cXmlElement* pAnimElem = it.Next()->ToElement();
 
-				pMat->AddUvAnimation(animType,fSpeed,fAmp, animAxis);
-			}
-		}
+                eMaterialUvAnimation animType = GetUvAnimType(pAnimElem->GetAttributeString("Type").c_str());
+                eMaterialAnimationAxis animAxis = GetAnimAxis(pAnimElem->GetAttributeString("Axis").c_str());
+                float fSpeed = pAnimElem->GetAttributeFloat("Speed", 0);
+                float fAmp = pAnimElem->GetAttributeFloat("Amplitude", 0);
 
+                pMat->AddUvAnimation(animType, fSpeed, fAmp, animAxis);
+            }
+        }
 
-		///////////////////////////
-		//Variables
-		cXmlElement* pUserVarsRoot = pDoc->GetFirstElement("SpecificVariables");
-		cResourceVarsObject userVars;
-		if(pUserVarsRoot) userVars.LoadVariables(pUserVarsRoot);
+        ///////////////////////////
+        // Variables
+        cXmlElement* pUserVarsRoot = pDoc->GetFirstElement("SpecificVariables");
+        cResourceVarsObject userVars;
+        if (pUserVarsRoot)
+            userVars.LoadVariables(pUserVarsRoot);
 
-		pMatType->LoadVariables(pMat, &userVars);
-
-		tString materialID = cString::ToLowerCase(sType);
-		auto& typeInfo = pMat->type();
-		for(auto& meta: cMaterial::MaterialMetaTable) {
-			if(materialID == meta.m_name) {
-				if(meta.m_isTranslucent) {
-			        pMat->SetBlendMode(GetBlendMode(sBlendMode));
-			    }
-			    auto& type = pMat->type();
-				type.m_id = meta.m_id;
-				type.m_handle = IndexPoolHandle(&internal::m_MaterialIndexPool);
-			    MaterialDescriptor materialDescriptor;
-			    materialDescriptor.m_id = meta.m_id;
-			    switch(meta.m_id) {
-					case MaterialID::SolidDiffuse: {
-					    type.m_data.m_solid.m_heightMapScale = userVars.GetVarFloat("HeightMapScale", 0.1f);
-						type.m_data.m_solid.m_heightMapBias = userVars.GetVarFloat("HeightMapBias", 0);
-						type.m_data.m_solid.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
-						type.m_data.m_solid.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
-						type.m_alphaDissolveFilter = userVars.GetVarBool("AlphaDissolveFilter", false);
+        tString materialID = cString::ToLowerCase(sType);
+        for (auto& meta : cMaterial::MaterialMetaTable) {
+            if (materialID == meta.m_name) {
+                pMat->SetHandle(IndexPoolHandle(&internal::m_MaterialIndexPool));
+                MaterialDescriptor materialDescriptor;
+                materialDescriptor.m_id = meta.m_id;
+                switch (meta.m_id) {
+                case MaterialID::SolidDiffuse:
+                    {
+                        //	    type.m_data.m_solid.m_heightMapScale = userVars.GetVarFloat("HeightMapScale", 0.1f);
+                        //		type.m_data.m_solid.m_heightMapBias = userVars.GetVarFloat("HeightMapBias", 0);
+                        //		type.m_data.m_solid.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
+                        //		type.m_data.m_solid.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
+                        //		type.m_alphaDissolveFilter = userVars.GetVarBool("AlphaDissolveFilter", false);
 
                         materialDescriptor.m_solid.m_heightMapScale = userVars.GetVarFloat("HeightMapScale", 0.1f);
-				        materialDescriptor.m_solid.m_heightMapBias = userVars.GetVarFloat("HeightMapBias", 0);
-				        materialDescriptor.m_solid.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
-				        materialDescriptor.m_solid.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
-				        materialDescriptor.m_solid.m_alphaDissolveFilter = userVars.GetVarBool("AlphaDissolveFilter", false);
-						break;
-					}
-					case MaterialID::Translucent: {
-						pMat->SetHasRefraction(userVars.GetVarBool("Refraction", false));
-						pMat->SetIsAffectedByLightLevel(userVars.GetVarBool("AffectedByLightLevel", false));
-						pMat->SetHasRefractionNormals(userVars.GetVarBool("RefractionNormals", true));
-						pMat->SetUseRefractionEdgeCheck(userVars.GetVarBool("RefractionEdgeCheck", true));
-						type.m_data.m_translucentUniformBlock.mfRefractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
-						type.m_data.m_translucentUniformBlock.mfFrenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
-						type.m_data.m_translucentUniformBlock.mfFrenselPow = userVars.GetVarFloat("FrenselPow", 8.0);
-						type.m_data.m_translucentUniformBlock.mfRimLightMul = userVars.GetVarFloat("RimLightMul", 0.0f);
-						type.m_data.m_translucentUniformBlock.mfRimLightPow = userVars.GetVarFloat("RimLightPow", 8.0f);
+                        materialDescriptor.m_solid.m_heightMapBias = userVars.GetVarFloat("HeightMapBias", 0);
+                        materialDescriptor.m_solid.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
+                        materialDescriptor.m_solid.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
+                        materialDescriptor.m_solid.m_alphaDissolveFilter = userVars.GetVarBool("AlphaDissolveFilter", false);
+                        break;
+                    }
+                case MaterialID::Translucent:
+                    {
+                       // pMat->SetHasRefraction(userVars.GetVarBool("Refraction", false));
+                       // pMat->SetIsAffectedByLightLevel(userVars.GetVarBool("AffectedByLightLevel", false));
+                       // pMat->SetHasRefractionNormals(userVars.GetVarBool("RefractionNormals", true));
+                       // pMat->SetUseRefractionEdgeCheck(userVars.GetVarBool("RefractionEdgeCheck", true));
+                        //		type.m_data.m_translucentUniformBlock.mfRefractionScale =
+                        //userVars.GetVarFloat("RefractionScale", 1.0f); 		type.m_data.m_translucentUniformBlock.mfFrenselBias =
+                        //userVars.GetVarFloat("FrenselBias", 0.2f); 		type.m_data.m_translucentUniformBlock.mfFrenselPow =
+                        //userVars.GetVarFloat("FrenselPow", 8.0); 		type.m_data.m_translucentUniformBlock.mfRimLightMul =
+                        //userVars.GetVarFloat("RimLightMul", 0.0f); 		type.m_data.m_translucentUniformBlock.mfRimLightPow =
+                        //userVars.GetVarFloat("RimLightPow", 8.0f);
 
                         materialDescriptor.m_translucent.m_hasRefraction = userVars.GetVarBool("Refraction", false);
-				        materialDescriptor.m_translucent.m_refractionNormals = userVars.GetVarBool("RefractionNormals", true);
-				        materialDescriptor.m_translucent.m_refractionEdgeCheck = userVars.GetVarBool("RefractionEdgeCheck", true);
+                        materialDescriptor.m_translucent.m_refractionNormals = userVars.GetVarBool("RefractionNormals", true);
+                        materialDescriptor.m_translucent.m_refractionEdgeCheck = userVars.GetVarBool("RefractionEdgeCheck", true);
                         materialDescriptor.m_translucent.m_isAffectedByLightLevel = userVars.GetVarBool("AffectedByLightLevel", false);
 
-			            materialDescriptor.m_translucent.m_refractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
-			            materialDescriptor.m_translucent.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
-				        materialDescriptor.m_translucent.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0);
-				        materialDescriptor.m_translucent.m_rimLightMul = userVars.GetVarFloat("RimLightMul", 0.0f);
-				        materialDescriptor.m_translucent.m_rimLightPow = userVars.GetVarFloat("RimLightPow", 8.0f);
-				        materialDescriptor.m_translucent.m_blend = GetBlendMode(sBlendMode);
-					    break;
-					}
-					case MaterialID::Water: {
-						// type.m_data.m_waterUniformBlock.mbHasReflection = userVars.GetVarBool("HasReflection", true);
-						type.m_data.m_waterUniformBlock.mfRefractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
-						type.m_data.m_waterUniformBlock.mfFrenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
-						type.m_data.m_waterUniformBlock.mfFrenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
-						type.m_data.m_waterUniformBlock.mfReflectionFadeStart = userVars.GetVarFloat("ReflectionFadeStart", 0);
-						type.m_data.m_waterUniformBlock.mfReflectionFadeEnd = userVars.GetVarFloat("ReflectionFadeEnd", 0);
-						type.m_data.m_waterUniformBlock.mfWaveSpeed = userVars.GetVarFloat("WaveSpeed", 1.0f);
-						type.m_data.m_waterUniformBlock.mfWaveAmplitude = userVars.GetVarFloat("WaveAmplitude", 1.0f);
-						type.m_data.m_waterUniformBlock.mfWaveFreq = userVars.GetVarFloat("WaveFreq", 1.0f);
+                        materialDescriptor.m_translucent.m_refractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
+                        materialDescriptor.m_translucent.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
+                        materialDescriptor.m_translucent.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0);
+                        materialDescriptor.m_translucent.m_rimLightMul = userVars.GetVarFloat("RimLightMul", 0.0f);
+                        materialDescriptor.m_translucent.m_rimLightPow = userVars.GetVarFloat("RimLightPow", 8.0f);
+                        materialDescriptor.m_translucent.m_blend = GetBlendMode(sBlendMode);
+                        break;
+                    }
+                case MaterialID::Water:
+                    {
+                        // type.m_data.m_waterUniformBlock.mbHasReflection = userVars.GetVarBool("HasReflection", true);
+                        //	type.m_data.m_waterUniformBlock.mfRefractionScale =
+                        // userVars.GetVarFloat("RefractionScale", 1.0f); 		type.m_data.m_waterUniformBlock.mfFrenselBias =
+                        // userVars.GetVarFloat("FrenselBias", 0.2f); 		type.m_data.m_waterUniformBlock.mfFrenselPow =
+                        // userVars.GetVarFloat("FrenselPow", 8.0f);
+                        //		type.m_data.m_waterUniformBlock.mfReflectionFadeStart =
+                        // userVars.GetVarFloat("ReflectionFadeStart", 0);
+                        //		type.m_data.m_waterUniformBlock.mfReflectionFadeEnd =
+                        // userVars.GetVarFloat("ReflectionFadeEnd", 0); 		type.m_data.m_waterUniformBlock.mfWaveSpeed =
+                        // userVars.GetVarFloat("WaveSpeed", 1.0f); 		type.m_data.m_waterUniformBlock.mfWaveAmplitude =
+                        // userVars.GetVarFloat("WaveAmplitude", 1.0f); 		type.m_data.m_waterUniformBlock.mfWaveFreq =
+                        // userVars.GetVarFloat("WaveFreq", 1.0f);
 
-						pMat->SetWorldReflectionOcclusionTest(userVars.GetVarBool("OcclusionCullWorldReflection", true));
-						pMat->SetMaxReflectionDistance(userVars.GetVarFloat("ReflectionFadeEnd", 0.0f));
-						pMat->SetLargeTransperantSurface(userVars.GetVarBool("LargeSurface", false));
+                        //pMat->SetWorldReflectionOcclusionTest(userVars.GetVarBool("OcclusionCullWorldReflection", true));
+                        //pMat->SetMaxReflectionDistance(userVars.GetVarFloat("ReflectionFadeEnd", 0.0f));
+                        //pMat->SetLargeTransperantSurface(userVars.GetVarBool("LargeSurface", false));
 
-					    materialDescriptor.m_water.m_hasReflection = userVars.GetVarBool("HasReflection", true);
-				        materialDescriptor.m_water.m_refractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
-				        materialDescriptor.m_water.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
-				        materialDescriptor.m_water.mfFrenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
-				        materialDescriptor.m_water.mfReflectionFadeStart = userVars.GetVarFloat("ReflectionFadeStart", 0);
-				        materialDescriptor.m_water.mfReflectionFadeEnd = userVars.GetVarFloat("ReflectionFadeEnd", 0);
-				        materialDescriptor.m_water.mfWaveSpeed = userVars.GetVarFloat("WaveSpeed", 1.0f);
-				        materialDescriptor.m_water.mfWaveAmplitude = userVars.GetVarFloat("WaveAmplitude", 1.0f);
-				        materialDescriptor.m_water.mfWaveFreq = userVars.GetVarFloat("WaveFreq", 1.0f);
-                        materialDescriptor.m_water.m_maxReflectionDistance = userVars.GetVarFloat("ReflectionFadeEnd", 0.0f);
+                        materialDescriptor.m_water.m_hasReflection = userVars.GetVarBool("HasReflection", true);
+                        materialDescriptor.m_water.m_refractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
+                        materialDescriptor.m_water.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
+                        materialDescriptor.m_water.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
+                        materialDescriptor.m_water.m_reflectionFadeStart = userVars.GetVarFloat("ReflectionFadeStart", 0);
+                        materialDescriptor.m_water.m_reflectionFadeEnd = userVars.GetVarFloat("ReflectionFadeEnd", 0);
+                        materialDescriptor.m_water.m_waveSpeed = userVars.GetVarFloat("WaveSpeed", 1.0f);
+                        materialDescriptor.m_water.m_waveAmplitude = userVars.GetVarFloat("WaveAmplitude", 1.0f);
+                        materialDescriptor.m_water.m_waveFreq = userVars.GetVarFloat("WaveFreq", 1.0f);
 
                         materialDescriptor.m_water.m_isLargeSurface = userVars.GetVarBool("LargeSurface", false);
-						break;
-					}
-					case MaterialID::Decal: {
+                        materialDescriptor.m_water.m_worldReflectionOcclusionTest = userVars.GetVarBool("OcclusionCullWorldReflection", true);
+                        break;
+                    }
+                case MaterialID::Decal:
+                    {
                         materialDescriptor.m_translucent.m_blend = GetBlendMode(sBlendMode);
-					    break;
-					}
-					default:
-						ASSERT(false && "Invalid material type");
-						break;
-				}
-			    pMat->SetDescriptor(materialDescriptor);
-				break;
-			}
-		}
+                        break;
+                    }
+                default:
+                    ASSERT(false && "Invalid material type");
+                    break;
+                }
+                pMat->SetDescriptor(materialDescriptor);
+                break;
+            }
+        }
 
-		mpResources->DestroyXmlDocument(pDoc);
+        mpResources->DestroyXmlDocument(pDoc);
 
-		pMat->Compile();
+        pMat->Compile();
 
-		return pMat;
-	}
+        return pMat;
+    }
 
-	//-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
 
-	eTextureType cMaterialManager::GetType(const tString& asType)
-	{
-		if(cString::ToLowerCase(asType) == "cube") return eTextureType_CubeMap;
-		else if(cString::ToLowerCase(asType) == "1d") return eTextureType_1D;
-		else if(cString::ToLowerCase(asType) == "2d") return eTextureType_2D;
-		else if(cString::ToLowerCase(asType) == "3d") return eTextureType_3D;
+    eTextureType cMaterialManager::GetType(const tString& asType) {
+        if (cString::ToLowerCase(asType) == "cube")
+            return eTextureType_CubeMap;
+        else if (cString::ToLowerCase(asType) == "1d")
+            return eTextureType_1D;
+        else if (cString::ToLowerCase(asType) == "2d")
+            return eTextureType_2D;
+        else if (cString::ToLowerCase(asType) == "3d")
+            return eTextureType_3D;
 
-		return eTextureType_2D;
-	}
-	//-----------------------------------------------------------------------
+        return eTextureType_2D;
+    }
+    //-----------------------------------------------------------------------
 
-	tString cMaterialManager::GetTextureString(eMaterialTexture aType)
-	{
-		switch(aType)
-		{
-			case eMaterialTexture_Diffuse: return "Diffuse";
-			case eMaterialTexture_Alpha: return "Alpha";
-			case eMaterialTexture_NMap: return "NMap";
-			case eMaterialTexture_Height: return "Height";
-			case eMaterialTexture_Illumination: return "Illumination";
-			case eMaterialTexture_Specular: return "Specular";
-			case eMaterialTexture_CubeMap: return "CubeMap";
-			case eMaterialTexture_DissolveAlpha: return "DissolveAlpha";
-			case eMaterialTexture_CubeMapAlpha: return "CubeMapAlpha";
-		}
+    tString cMaterialManager::GetTextureString(eMaterialTexture aType) {
+        switch (aType) {
+        case eMaterialTexture_Diffuse:
+            return "Diffuse";
+        case eMaterialTexture_Alpha:
+            return "Alpha";
+        case eMaterialTexture_NMap:
+            return "NMap";
+        case eMaterialTexture_Height:
+            return "Height";
+        case eMaterialTexture_Illumination:
+            return "Illumination";
+        case eMaterialTexture_Specular:
+            return "Specular";
+        case eMaterialTexture_CubeMap:
+            return "CubeMap";
+        case eMaterialTexture_DissolveAlpha:
+            return "DissolveAlpha";
+        case eMaterialTexture_CubeMapAlpha:
+            return "CubeMapAlpha";
+        }
 
-		return "";
-	}
+        return "";
+    }
 
-	//-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
 
-	eTextureWrap cMaterialManager::GetWrap(const tString& asType)
-	{
-		if(cString::ToLowerCase(asType) == "repeat") return eTextureWrap_Repeat;
-		else if(cString::ToLowerCase(asType) == "clamp") return eTextureWrap_Clamp;
-		else if(cString::ToLowerCase(asType) == "clamptoedge") return eTextureWrap_ClampToEdge;
+    eTextureWrap cMaterialManager::GetWrap(const tString& asType) {
+        if (cString::ToLowerCase(asType) == "repeat")
+            return eTextureWrap_Repeat;
+        else if (cString::ToLowerCase(asType) == "clamp")
+            return eTextureWrap_Clamp;
+        else if (cString::ToLowerCase(asType) == "clamptoedge")
+            return eTextureWrap_ClampToEdge;
+        return eTextureWrap_Repeat;
+    }
 
-		return eTextureWrap_Repeat;
-	}
+    eTextureAnimMode cMaterialManager::GetAnimMode(const tString& asType) {
+        if (cString::ToLowerCase(asType) == "none")
+            return eTextureAnimMode_None;
+        else if (cString::ToLowerCase(asType) == "loop")
+            return eTextureAnimMode_Loop;
+        else if (cString::ToLowerCase(asType) == "oscillate")
+            return eTextureAnimMode_Oscillate;
+        return eTextureAnimMode_None;
+    }
 
-	eTextureAnimMode cMaterialManager::GetAnimMode(const tString& asType)
-	{
-		if(cString::ToLowerCase(asType) == "none") return eTextureAnimMode_None;
-		else if(cString::ToLowerCase(asType) == "loop") return eTextureAnimMode_Loop;
-		else if(cString::ToLowerCase(asType) == "oscillate") return eTextureAnimMode_Oscillate;
+    //-----------------------------------------------------------------------
 
-		return eTextureAnimMode_None;
-	}
+    eMaterialBlendMode cMaterialManager::GetBlendMode(const tString& asType) {
+        tString sLow = cString::ToLowerCase(asType);
+        if (sLow == "add")
+            return eMaterialBlendMode_Add;
+        if (sLow == "mul")
+            return eMaterialBlendMode_Mul;
+        if (sLow == "mulx2")
+            return eMaterialBlendMode_MulX2;
+        if (sLow == "alpha")
+            return eMaterialBlendMode_Alpha;
+        if (sLow == "premulalpha")
+            return eMaterialBlendMode_PremulAlpha;
 
-	//-----------------------------------------------------------------------
+        Warning("Material BlendMode '%s' does not exist!\n", asType.c_str());
 
-	eMaterialBlendMode cMaterialManager::GetBlendMode(const tString& asType)
-	{
-		tString sLow = cString::ToLowerCase(asType);
-		if(sLow == "add")	return eMaterialBlendMode_Add;
-		if(sLow == "mul")	return eMaterialBlendMode_Mul;
-		if(sLow == "mulx2")	return eMaterialBlendMode_MulX2;
-		if(sLow == "alpha")	return eMaterialBlendMode_Alpha;
-		if(sLow == "premulalpha")	return eMaterialBlendMode_PremulAlpha;
+        return eMaterialBlendMode_Add;
+    }
 
-		Warning("Material BlendMode '%s' does not exist!\n",asType.c_str());
+    //-----------------------------------------------------------------------
 
-		return eMaterialBlendMode_Add;
-	}
+    eMaterialUvAnimation cMaterialManager::GetUvAnimType(const char* apString) {
+        if (apString == NULL) {
+            Error("Uv animation attribute Type does not exist!\n");
+            return eMaterialUvAnimation_LastEnum;
+        }
 
-	//-----------------------------------------------------------------------
+        tString sLow = cString::ToLowerCase(apString);
 
-	eMaterialUvAnimation cMaterialManager::GetUvAnimType(const char* apString)
-	{
-		if(apString==NULL){
-			Error("Uv animation attribute Type does not exist!\n");
-			return eMaterialUvAnimation_LastEnum;
-		}
+        if (sLow == "translate")
+            return eMaterialUvAnimation_Translate;
+        if (sLow == "sin")
+            return eMaterialUvAnimation_Sin;
+        if (sLow == "rotate")
+            return eMaterialUvAnimation_Rotate;
 
-		tString sLow = cString::ToLowerCase(apString);
+        Error("Invalid uv animation type %s\n", apString);
+        return eMaterialUvAnimation_LastEnum;
+    }
 
-		if(sLow == "translate") return eMaterialUvAnimation_Translate;
-		if(sLow == "sin") return eMaterialUvAnimation_Sin;
-		if(sLow == "rotate") return eMaterialUvAnimation_Rotate;
+    eMaterialAnimationAxis cMaterialManager::GetAnimAxis(const char* apString) {
+        if (apString == NULL) {
+            Error("Uv animation attribute Axis does not exist!\n");
+            return eMaterialAnimationAxis_LastEnum;
+        }
 
-		Error("Invalid uv animation type %s\n",apString);
-		return eMaterialUvAnimation_LastEnum;
-	}
+        tString sLow = cString::ToLowerCase(apString);
 
-	eMaterialAnimationAxis cMaterialManager::GetAnimAxis(const char* apString)
-	{
-		if(apString==NULL){
-			Error("Uv animation attribute Axis does not exist!\n");
-			return eMaterialAnimationAxis_LastEnum;
-		}
+        if (sLow == "x")
+            return eMaterialAnimationAxis_X;
+        if (sLow == "y")
+            return eMaterialAnimationAxis_Y;
+        if (sLow == "z")
+            return eMaterialAnimationAxis_Z;
 
-		tString sLow = cString::ToLowerCase(apString);
+        Error("Invalid animation axis %s\n", apString);
+        return eMaterialAnimationAxis_LastEnum;
+    }
 
-		if(sLow == "x") return eMaterialAnimationAxis_X;
-		if(sLow == "y") return eMaterialAnimationAxis_Y;
-		if(sLow == "z") return eMaterialAnimationAxis_Z;
-
-		Error("Invalid animation axis %s\n",apString);
-		return eMaterialAnimationAxis_LastEnum;
-	}
-
-	//-----------------------------------------------------------------------
-}
+    //-----------------------------------------------------------------------
+} // namespace hpl

--- a/HPL2/sources/resources/MaterialManager.cpp
+++ b/HPL2/sources/resources/MaterialManager.cpp
@@ -47,32 +47,6 @@ namespace hpl {
         static IndexPool m_MaterialIndexPool(cMaterial::MaxMaterialID);
     }
 
-    class cMaterialManagerBlankMaterialType_Vars : public iMaterialVars {};
-
-    class cMaterialManagerBlankMaterialType : public iMaterialType {
-    public:
-        cMaterialManagerBlankMaterialType()
-            : iMaterialType(NULL, NULL) {
-        }
-
-        void LoadData() override {
-        }
-        void DestroyData() override {
-        }
-
-        iMaterialVars* CreateSpecificVariables() override {
-            return hplNew(cMaterialManagerBlankMaterialType_Vars, ());
-        }
-        void LoadVariables(cMaterial* apMaterial, cResourceVarsObject* apVars) override {
-        }
-        void GetVariableValues(cMaterial* apMaterial, cResourceVarsObject* apVars) override {
-        }
-
-        void CompileMaterialSpecifics(cMaterial* apMaterial) {
-        }
-    };
-
-    cMaterialManagerBlankMaterialType gBlankMaterialType;
     cMaterialManager::cMaterialManager(cGraphics* apGraphics, cResources* apResources)
         : iResourceManager(apResources->GetFileSearcher(), apResources->GetLowLevel(), apResources->GetLowLevelSystem()) {
         mpGraphics = apGraphics;
@@ -214,7 +188,7 @@ namespace hpl {
     //-----------------------------------------------------------------------
 
     cMaterial* cMaterialManager::CreateCustomMaterial(const tString& asName, iMaterialType* apMaterialType) {
-        cMaterial* pMat = hplNew(cMaterial, (asName, cString::To16Char(asName), mpGraphics, mpResources));
+        cMaterial* pMat = hplNew(cMaterial, (asName, cString::To16Char(asName), mpResources));
         pMat->IncUserCount();
         AddResource(pMat);
         return pMat;
@@ -251,7 +225,7 @@ namespace hpl {
         /////////////////////////////
         // Make a "fake" material, with a blank type
         if (mbDisableRenderDataLoading) {
-            cMaterial* pMat = hplNew(cMaterial, (asName, asPath, mpGraphics, mpResources));
+            cMaterial* pMat = hplNew(cMaterial, (asName, asPath, mpResources));
             pMat->SetPhysicsMaterial(sPhysicsMatName);
 
             mpResources->DestroyXmlDocument(pDoc);
@@ -270,7 +244,7 @@ namespace hpl {
             LOGF(eERROR, "Invalid material type %s", sType.c_str());
             return NULL;
         }
-        cMaterial* pMat = new cMaterial(asName, asPath, mpGraphics, mpResources);
+        cMaterial* pMat = new cMaterial(asName, asPath, mpResources);
         pMat->SetDepthTest(bDepthTest);
         pMat->SetPhysicsMaterial(sPhysicsMatName);
 
@@ -482,7 +456,6 @@ namespace hpl {
 
         mpResources->DestroyXmlDocument(pDoc);
 
-        pMat->Compile();
 
         return pMat;
     }

--- a/HPL2/sources/resources/MaterialManager.cpp
+++ b/HPL2/sources/resources/MaterialManager.cpp
@@ -423,33 +423,48 @@ namespace hpl {
 			    auto& type = pMat->type();
 				type.m_id = meta.m_id;
 				type.m_handle = IndexPoolHandle(&internal::m_MaterialIndexPool);
-				//type.m_data.m_common.m_textureConfig
+			    MaterialDescriptor materialDescriptor;
+			    materialDescriptor.m_id = meta.m_id;
 			    switch(meta.m_id) {
-					case cMaterial::MaterialID::SolidDiffuse: {
+					case MaterialID::SolidDiffuse: {
 					    type.m_data.m_solid.m_heightMapScale = userVars.GetVarFloat("HeightMapScale", 0.1f);
 						type.m_data.m_solid.m_heightMapBias = userVars.GetVarFloat("HeightMapBias", 0);
 						type.m_data.m_solid.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
 						type.m_data.m_solid.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
 						type.m_alphaDissolveFilter = userVars.GetVarBool("AlphaDissolveFilter", false);
+
+                        materialDescriptor.m_solid.m_heightMapScale = userVars.GetVarFloat("HeightMapScale", 0.1f);
+				        materialDescriptor.m_solid.m_heightMapBias = userVars.GetVarFloat("HeightMapBias", 0);
+				        materialDescriptor.m_solid.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
+				        materialDescriptor.m_solid.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
+				        materialDescriptor.m_solid.m_alphaDissolveFilter = userVars.GetVarBool("AlphaDissolveFilter", false);
 						break;
 					}
-					case cMaterial::MaterialID::Translucent: {
+					case MaterialID::Translucent: {
 						pMat->SetHasRefraction(userVars.GetVarBool("Refraction", false));
 						pMat->SetIsAffectedByLightLevel(userVars.GetVarBool("AffectedByLightLevel", false));
 						pMat->SetHasRefractionNormals(userVars.GetVarBool("RefractionNormals", true));
 						pMat->SetUseRefractionEdgeCheck(userVars.GetVarBool("RefractionEdgeCheck", true));
-
-						// type.m_data.m_translucentUniformBlock.mbRefraction = userVars.GetVarBool("Refraction", false);
-						// type.m_data.m_translucentUniformBlock.mbRefractionEdgeCheck = userVars.GetVarBool("RefractionEdgeCheck", true);
 						type.m_data.m_translucentUniformBlock.mfRefractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
 						type.m_data.m_translucentUniformBlock.mfFrenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
 						type.m_data.m_translucentUniformBlock.mfFrenselPow = userVars.GetVarFloat("FrenselPow", 8.0);
 						type.m_data.m_translucentUniformBlock.mfRimLightMul = userVars.GetVarFloat("RimLightMul", 0.0f);
 						type.m_data.m_translucentUniformBlock.mfRimLightPow = userVars.GetVarFloat("RimLightPow", 8.0f);
-						// type.m_data.m_translucentUniformBlock.mbAffectedByLightLevel = userVars.GetVarBool("AffectedByLightLevel", false);
-						break;
+
+                        materialDescriptor.m_translucent.m_hasRefraction = userVars.GetVarBool("Refraction", false);
+				        materialDescriptor.m_translucent.m_refractionNormals = userVars.GetVarBool("RefractionNormals", true);
+				        materialDescriptor.m_translucent.m_refractionEdgeCheck = userVars.GetVarBool("RefractionEdgeCheck", true);
+                        materialDescriptor.m_translucent.m_isAffectedByLightLevel = userVars.GetVarBool("AffectedByLightLevel", false);
+
+			            materialDescriptor.m_translucent.m_refractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
+			            materialDescriptor.m_translucent.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
+				        materialDescriptor.m_translucent.m_frenselPow = userVars.GetVarFloat("FrenselPow", 8.0);
+				        materialDescriptor.m_translucent.m_rimLightMul = userVars.GetVarFloat("RimLightMul", 0.0f);
+				        materialDescriptor.m_translucent.m_rimLightPow = userVars.GetVarFloat("RimLightPow", 8.0f);
+				        materialDescriptor.m_translucent.m_blend = GetBlendMode(sBlendMode);
+					    break;
 					}
-					case cMaterial::MaterialID::Water: {
+					case MaterialID::Water: {
 						// type.m_data.m_waterUniformBlock.mbHasReflection = userVars.GetVarBool("HasReflection", true);
 						type.m_data.m_waterUniformBlock.mfRefractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
 						type.m_data.m_waterUniformBlock.mfFrenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
@@ -463,16 +478,30 @@ namespace hpl {
 						pMat->SetWorldReflectionOcclusionTest(userVars.GetVarBool("OcclusionCullWorldReflection", true));
 						pMat->SetMaxReflectionDistance(userVars.GetVarFloat("ReflectionFadeEnd", 0.0f));
 						pMat->SetLargeTransperantSurface(userVars.GetVarBool("LargeSurface", false));
+
+					    materialDescriptor.m_water.m_hasReflection = userVars.GetVarBool("HasReflection", true);
+				        materialDescriptor.m_water.m_refractionScale = userVars.GetVarFloat("RefractionScale", 1.0f);
+				        materialDescriptor.m_water.m_frenselBias = userVars.GetVarFloat("FrenselBias", 0.2f);
+				        materialDescriptor.m_water.mfFrenselPow = userVars.GetVarFloat("FrenselPow", 8.0f);
+				        materialDescriptor.m_water.mfReflectionFadeStart = userVars.GetVarFloat("ReflectionFadeStart", 0);
+				        materialDescriptor.m_water.mfReflectionFadeEnd = userVars.GetVarFloat("ReflectionFadeEnd", 0);
+				        materialDescriptor.m_water.mfWaveSpeed = userVars.GetVarFloat("WaveSpeed", 1.0f);
+				        materialDescriptor.m_water.mfWaveAmplitude = userVars.GetVarFloat("WaveAmplitude", 1.0f);
+				        materialDescriptor.m_water.mfWaveFreq = userVars.GetVarFloat("WaveFreq", 1.0f);
+                        materialDescriptor.m_water.m_maxReflectionDistance = userVars.GetVarFloat("ReflectionFadeEnd", 0.0f);
+
+                        materialDescriptor.m_water.m_isLargeSurface = userVars.GetVarBool("LargeSurface", false);
 						break;
 					}
-					case cMaterial::MaterialID::Decal: {
-						// no uniform block
-						break;
+					case MaterialID::Decal: {
+                        materialDescriptor.m_translucent.m_blend = GetBlendMode(sBlendMode);
+					    break;
 					}
 					default:
 						ASSERT(false && "Invalid material type");
 						break;
 				}
+			    pMat->SetDescriptor(materialDescriptor);
 				break;
 			}
 		}

--- a/HPL2/sources/scene/Beam.cpp
+++ b/HPL2/sources/scene/Beam.cpp
@@ -285,7 +285,7 @@ namespace hpl {
 			pTex+=3;
 		}
 
-		if(mpMaterial->GetType()->IsTranslucent())
+		if(cMaterial::IsTranslucent(mpMaterial->Descriptor().m_id))
 		{
 			mpVtxBuffer->UpdateData(eVertexElementFlag_Position | eVertexElementFlag_Texture0,false);
 		}
@@ -293,9 +293,6 @@ namespace hpl {
 		{
 			mpVtxBuffer->UpdateData(eVertexElementFlag_Position | eVertexElementFlag_Texture0,false);
 		}
-
-
-
 	}
 
 	//-----------------------------------------------------------------------

--- a/amnesia/game/LuxEffectRenderer.cpp
+++ b/amnesia/game/LuxEffectRenderer.cpp
@@ -23,6 +23,7 @@
 #include "engine/Interface.h"
 #include <graphics/Enum.h>
 #include <graphics/RenderTarget.h>
+#include <graphics/MaterialResource.h>
 #include <math/MathTypes.h>
 #include <memory>
 #include <vector>
@@ -796,7 +797,7 @@ void cLuxEffectRenderer::RenderTrans(cViewport::PostTranslucenceDrawPacket&  inp
 
             LuxEffectObjectUniform::OutlineUniform  uniform{};
             uniform.m_mvp = cMath::ToForgeMat4(cMath::MatrixMul(mainFrustumViewProj, worldMatrix).GetTranspose());
-            uniform.m_feature = pMaterial->type().m_data.m_common.m_materialConfig;
+            uniform.m_feature = hpl::material::UniformMaterialBlock::CreateMaterailConfigFlags(*pMaterial);
 
             BufferUpdateDesc updateDesc = { uniformBlockOffset.pBuffer, uniformBlockOffset.mOffset };
             beginUpdateResource(&updateDesc);
@@ -831,7 +832,6 @@ void cLuxEffectRenderer::RenderTrans(cViewport::PostTranslucenceDrawPacket&  inp
         for(auto& pObject: filteredObjects) {
             auto* vertexBuffer = pObject->GetVertexBuffer();
             auto* pMaterial = pObject->GetMaterial();
-            auto& materialType = pMaterial->type();
             if (!pObject->CollidesWithFrustum(input.m_frustum)) {
                 continue;
             }
@@ -858,7 +858,7 @@ void cLuxEffectRenderer::RenderTrans(cViewport::PostTranslucenceDrawPacket&  inp
 
             LuxEffectObjectUniform::OutlineUniform uniform{};
             uniform.m_mvp = cMath::ToForgeMat4(cMath::MatrixMul(mainFrustumViewProj, cMath::MatrixMul(worldMatrix, mtxScale)).GetTranspose());
-            uniform.m_feature = pMaterial->type().m_data.m_common.m_materialConfig;
+            uniform.m_feature =hpl::material::UniformMaterialBlock::CreateMaterailConfigFlags(*pMaterial);
 
             BufferUpdateDesc updateDesc = { uniformBlockOffset.pBuffer, uniformBlockOffset.mOffset };
             beginUpdateResource(&updateDesc);

--- a/amnesia/game/LuxMapHelper.cpp
+++ b/amnesia/game/LuxMapHelper.cpp
@@ -64,7 +64,7 @@ bool cLuxLineOfSightCallback::BeforeIntersect(iPhysicsBody *apBody)
 				}
 
 				cMaterial *pMaterial = pSubMeshEnt->GetMaterial();
-				if(	pMaterial && pMaterial->GetType()->IsTranslucent()==false &&
+				if(	pMaterial && cMaterial::IsTranslucent(pMaterial->Descriptor().m_id)==false &&
 					(mbCheckShadow==false || pSubMeshEnt->GetRenderFlagBit(eRenderableFlag_ShadowCaster)) )
 				{
 					bFoundSolid = true;


### PR DESCRIPTION
tries to simplify all the material data in a format that is easier to work with. MaterialType does not manage shaders anymore this separates the data from the shading logic. this is how another renderer can be built alongside this one.