### PR TITLE
bugfix: remove parllax from pre/post z pass

### DIFF
--- a/HPL2/include/graphics/RendererDeferred.h
+++ b/HPL2/include/graphics/RendererDeferred.h
@@ -597,6 +597,7 @@ namespace hpl {
         std::array<std::array<LightResourceEntry, MaxLightUniforms>, ForgeRenderer::SwapChainLength> m_lightResources{};
         // z pass
         SharedShader m_zPassShader;
+        SharedShader m_zPassShadowShader;
         SharedPipeline m_zPassPipelineCCW;
         SharedPipeline m_zPassPipelineCW;
 

--- a/HPL2/resource/ShaderList.fsl
+++ b/HPL2/resource/ShaderList.fsl
@@ -1,9 +1,17 @@
 /// Copyright © 2009-2020 Frictional Games
 /// Copyright 2023 Michael Pollind
 /// SPDX-License-Identifier: GPL-3.0
-
-#vert solid_z.vert
+#vert solid_z_shadow.vert
     #include "solid_z.vert.fsl"
+#end
+
+#frag solid_z_shadow.frag
+    #define ALPHA_REJECT 0.5
+    #include "solid_z_shadow.frag.fsl"
+#end
+
+#vert solid_z_shadow.vert
+    #include "solid_z_shadow.vert.fsl"
 #end
 
 #frag solid_z.frag

--- a/HPL2/resource/pbr.h.fsl
+++ b/HPL2/resource/pbr.h.fsl
@@ -1,0 +1,17 @@
+// https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
+//
+float3 F_Schlick (float3 f0 , float f90 , float u ){
+    return f0 + ( f90 - f0 ) * pow (1. f - u , 5. f ) ;
+}
+
+float Fr_DisneyDiffuse(float NdotV ,float NdotL ,float LdotH ,float linearRoughness)
+{
+    float energyBias = lerp (0 , 0.5 , linearRoughness ) ;
+    float energyFactor = lerp (1.0 , 1.0 / 1.51 , linearRoughness ) ;
+    float fd90 = energyBias + 2.0 * LdotH * LdotH * linearRoughness ;
+    float3 f0 = float3 (1.0 f , 1.0 f , 1.0 f ) ;
+    float lightScatter = F_Schlick ( f0 , fd90 , NdotL ) * r ;
+    float viewScatter = F_Schlick ( f0 , fd90 , NdotV ) * r ;
+
+    return lightScatter * viewScatter * energyFactor ;
+}

--- a/HPL2/resource/solid_diffuse.frag.fsl
+++ b/HPL2/resource/solid_diffuse.frag.fsl
@@ -43,8 +43,38 @@ PsOut PS_MAIN(PsIn In)
     }
 #endif
 
+    float diffuseAlpha;
+    if(HasAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        if(IsAlphaSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).r;
+        } else {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).a;
+        }
+    } else {
+        diffuseAlpha = 1.0;
+    }
+
+    const float dissolveAmount = Get(uniformObjectBuffer)[Get(objectId)].dissolveAmount;
+
+    if(dissolveAmount < 1.0 || HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig) || HasDissolveFilter(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        float2 vDissolveCoords = In.Position.xy * (1.0/128.0); //128 = size of dissolve texture.
+        float fDissolve = SampleTex2D(dissolveMap, Get(dissolveSampler), vDissolveCoords).x;
+        
+        if(HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            //Get in 0.75 - 1 range
+            fDissolve = fDissolve*0.25 + 0.75;
+
+            float fDissolveAlpha = SampleTex2D(Get(dissolveAlphaMap), Get(materialSampler), texCoord.xy).r;
+            fDissolve -= (0.25 - fDissolveAlpha * 0.25);
+        } else {
+            //Get in 0.5 - 1 range.
+            fDissolve = fDissolve*0.5 + 0.5;
+        }
+        diffuseAlpha = fDissolve -  (1.0 - (dissolveAmount * diffuseAlpha)) * 0.5;
+    }
+    
     float4 diffuseColor = SampleTex2D(Get(diffuseMap), Get(materialSampler), texCoord.xy);
-    if(diffuseColor.w < ALPHA_REJECT ) {
+    if(diffuseColor.w < ALPHA_REJECT || diffuseAlpha < ALPHA_REJECT) {
         discard;
     }
 

--- a/HPL2/resource/solid_z.frag.fsl
+++ b/HPL2/resource/solid_z.frag.fsl
@@ -8,67 +8,10 @@
 STRUCT(PsIn) 
 {
 	DATA(float4, Position, SV_Position);
-	DATA(float3, pos, POSITION);
-	DATA(float2, uv, TEXCOORD0);
-    DATA(float3, normal, NORMAL);
-    DATA(float3, tangent, TANGENT);
-    DATA(float3, bitangent, BITANGENT);
 };
 
 float4 PS_MAIN(PsIn In)
 {
     INIT_MAIN;
-    float2 texCoord = In.uv.xy;
-    uint materialID = Get(uniformObjectBuffer)[Get(objectId)].materialID;
-    
-    #ifdef PARALLAX_ENABLED
-        if(HasHeight(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-            texCoord.xy += ParallaxAdvance(texCoord,
-                0.0,
-                8.0, 
-                Get(uniformMaterialBuffer)[materialID].heightMapScale * PARALLAX_MULTIPLIER,
-                In.pos,
-                In.normal,
-                In.tangent,
-                In.bitangent,
-                IsHeightMapSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig));
-        }
-    #endif    
-    
-    float diffuseAlpha;
-    if(HasAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-        if(IsAlphaSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).r;
-        } else {
-            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).a;
-        }
-    } else {
-        diffuseAlpha = 1.0;
-    }
-
-    const float dissolveAmount = Get(uniformObjectBuffer)[Get(objectId)].dissolveAmount;
-
-    if(dissolveAmount < 1.0 || HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig) || HasDissolveFilter(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-        float2 vDissolveCoords = In.Position.xy * (1.0/128.0); //128 = size of dissolve texture.
-        float fDissolve = SampleTex2D(dissolveMap, Get(dissolveSampler), vDissolveCoords).x;
-        
-        if(HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-            //Get in 0.75 - 1 range
-            fDissolve = fDissolve*0.25 + 0.75;
-
-            float fDissolveAlpha = SampleTex2D(Get(dissolveAlphaMap), Get(materialSampler), texCoord.xy).r;
-            fDissolve -= (0.25 - fDissolveAlpha * 0.25);
-        } else {
-            //Get in 0.5 - 1 range.
-            fDissolve = fDissolve*0.5 + 0.5;
-        }
-        diffuseAlpha = fDissolve -  (1.0 - (dissolveAmount * diffuseAlpha)) * 0.5;
-    }
-
-    
-    if(diffuseAlpha < ALPHA_REJECT) {
-        discard;
-    }
-
     RETURN(float4(0,0,0,0));
 }

--- a/HPL2/resource/solid_z.vert.fsl
+++ b/HPL2/resource/solid_z.vert.fsl
@@ -5,19 +5,11 @@
 STRUCT(VSInput)
 {
 	DATA(float3, Position, POSITION);
-   // DATA(float2, TexCoord, TEXCOORD0);
-   // DATA(float3, Normal, NORMAL);
-   // DATA(float3, Tangent, TANGENT);
 };
 
 STRUCT(VSOutput)
 {
 	DATA(float4, Position, SV_Position);
- //   DATA(float3, pos, POSITION);
- //   DATA(float2, uv, TEXCOORD0);
- //   DATA(float3, normal, NORMAL);
- //   DATA(float3, tangent, TANGENT);
- //   DATA(float3, bitangent, BITANGENT);
 };
 
 VSOutput VS_MAIN(VSInput In)
@@ -28,14 +20,7 @@ VSOutput VS_MAIN(VSInput In)
     float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
     float4x4 modelViewPrj = mul(Get(projMat), modelView);
     
-//    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
     Out.Position = mul(modelViewPrj , float4(In.Position.xyz, 1.0));
-  //  Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
-    
-  //  float3x3 normalMat = ToNormalMat(Get(uniformObjectBuffer)[Get(objectId)].invModelMat, Get(invViewMat));
-  //  Out.normal = normalize(mul(normalMat, In.Normal.xyz));
-  //  Out.tangent = normalize(mul(normalMat, In.Tangent.xyz));
-  //  Out.bitangent = normalize(mul(normalMat, cross(In.Tangent.xyz, In.Normal.xyz)));
 
     RETURN(Out);
 }

--- a/HPL2/resource/solid_z.vert.fsl
+++ b/HPL2/resource/solid_z.vert.fsl
@@ -5,19 +5,19 @@
 STRUCT(VSInput)
 {
 	DATA(float3, Position, POSITION);
-	DATA(float2, TexCoord, TEXCOORD0);
-	DATA(float3, Normal, NORMAL);
-	DATA(float3, Tangent, TANGENT);
+   // DATA(float2, TexCoord, TEXCOORD0);
+   // DATA(float3, Normal, NORMAL);
+   // DATA(float3, Tangent, TANGENT);
 };
 
 STRUCT(VSOutput)
 {
 	DATA(float4, Position, SV_Position);
-	DATA(float3, pos, POSITION);
-	DATA(float2, uv, TEXCOORD0);
-	DATA(float3, normal, NORMAL);
-	DATA(float3, tangent, TANGENT);
-	DATA(float3, bitangent, BITANGENT);
+ //   DATA(float3, pos, POSITION);
+ //   DATA(float2, uv, TEXCOORD0);
+ //   DATA(float3, normal, NORMAL);
+ //   DATA(float3, tangent, TANGENT);
+ //   DATA(float3, bitangent, BITANGENT);
 };
 
 VSOutput VS_MAIN(VSInput In)
@@ -28,14 +28,14 @@ VSOutput VS_MAIN(VSInput In)
     float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
     float4x4 modelViewPrj = mul(Get(projMat), modelView);
     
-    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
+//    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
     Out.Position = mul(modelViewPrj , float4(In.Position.xyz, 1.0));
-    Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
+  //  Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
     
-    float3x3 normalMat = ToNormalMat(Get(uniformObjectBuffer)[Get(objectId)].invModelMat, Get(invViewMat));
-    Out.normal = normalize(mul(normalMat, In.Normal.xyz));
-    Out.tangent = normalize(mul(normalMat, In.Tangent.xyz));
-    Out.bitangent = normalize(mul(normalMat, cross(In.Tangent.xyz, In.Normal.xyz)));
+  //  float3x3 normalMat = ToNormalMat(Get(uniformObjectBuffer)[Get(objectId)].invModelMat, Get(invViewMat));
+  //  Out.normal = normalize(mul(normalMat, In.Normal.xyz));
+  //  Out.tangent = normalize(mul(normalMat, In.Tangent.xyz));
+  //  Out.bitangent = normalize(mul(normalMat, cross(In.Tangent.xyz, In.Normal.xyz)));
 
     RETURN(Out);
 }

--- a/HPL2/resource/solid_z_cut.vert.fsl
+++ b/HPL2/resource/solid_z_cut.vert.fsl
@@ -1,0 +1,30 @@
+#define MATERIAL_SOLID 1
+#include "deferred_resources.h.fsl"
+#include "deferred_common.h.fsl"
+
+STRUCT(VSInput)
+{
+	DATA(float3, Position, POSITION);
+	DATA(float2, TexCoord, TEXCOORD0);
+};
+
+STRUCT(VSOutput)
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float3, pos, POSITION);
+	DATA(float2, uv, TEXCOORD0);
+};
+
+VSOutput VS_MAIN(VSInput In)
+{
+    INIT_MAIN;
+    VSOutput Out;
+    
+    float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
+    float4x4 modelViewPrj = mul(Get(projMat), modelView);
+    
+    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
+    Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
+
+    RETURN(Out);
+}

--- a/HPL2/resource/solid_z_shadow.frag.fsl
+++ b/HPL2/resource/solid_z_shadow.frag.fsl
@@ -1,0 +1,56 @@
+/// Copyright © 2009-2020 Frictional Games
+/// Copyright 2023 Michael Pollind
+/// SPDX-License-Identifier: GPL-3.0
+#define MATERIAL_SOLID 1
+#include "deferred_resources.h.fsl"
+#include "deferred_common.h.fsl"
+
+STRUCT(PsIn) 
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float3, pos, POSITION);
+	DATA(float2, uv, TEXCOORD0);
+};
+
+float4 PS_MAIN(PsIn In)
+{
+    INIT_MAIN;
+    float2 texCoord = In.uv.xy;
+    uint materialID = Get(uniformObjectBuffer)[Get(objectId)].materialID;
+    float diffuseAlpha;
+    if(HasAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        if(IsAlphaSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).r;
+        } else {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).a;
+        }
+    } else {
+        diffuseAlpha = 1.0;
+    }
+
+    const float dissolveAmount = Get(uniformObjectBuffer)[Get(objectId)].dissolveAmount;
+
+    if(dissolveAmount < 1.0 || HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig) || HasDissolveFilter(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        float2 vDissolveCoords = In.Position.xy * (1.0/128.0); //128 = size of dissolve texture.
+        float fDissolve = SampleTex2D(dissolveMap, Get(dissolveSampler), vDissolveCoords).x;
+        
+        if(HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            //Get in 0.75 - 1 range
+            fDissolve = fDissolve*0.25 + 0.75;
+
+            float fDissolveAlpha = SampleTex2D(Get(dissolveAlphaMap), Get(materialSampler), texCoord.xy).r;
+            fDissolve -= (0.25 - fDissolveAlpha * 0.25);
+        } else {
+            //Get in 0.5 - 1 range.
+            fDissolve = fDissolve*0.5 + 0.5;
+        }
+        diffuseAlpha = fDissolve -  (1.0 - (dissolveAmount * diffuseAlpha)) * 0.5;
+    }
+
+    
+    if(diffuseAlpha < ALPHA_REJECT) {
+        discard;
+    }
+
+    RETURN(float4(0,0,0,0));
+}

--- a/HPL2/resource/solid_z_shadow.vert.fsl
+++ b/HPL2/resource/solid_z_shadow.vert.fsl
@@ -12,6 +12,7 @@ STRUCT(VSOutput)
 {
 	DATA(float4, Position, SV_Position);
 	DATA(float3, pos, POSITION);
+	DATA(float2, uv, TEXCOORD0);
 };
 
 VSOutput VS_MAIN(VSInput In)

--- a/HPL2/resource/solid_z_shadow.vert.fsl
+++ b/HPL2/resource/solid_z_shadow.vert.fsl
@@ -1,0 +1,28 @@
+#define MATERIAL_SOLID 1
+#include "deferred_resources.h.fsl"
+#include "deferred_common.h.fsl"
+
+STRUCT(VSInput)
+{
+	DATA(float3, Position, POSITION);
+	DATA(float2, TexCoord, TEXCOORD0);
+};
+
+STRUCT(VSOutput)
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float3, pos, POSITION);
+};
+
+VSOutput VS_MAIN(VSInput In)
+{
+    INIT_MAIN;
+    VSOutput Out;
+    
+    float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
+    float4x4 modelViewPrj = mul(Get(projMat), modelView);
+    
+    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
+    Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
+    RETURN(Out);
+}


### PR DESCRIPTION
calculating the parallax as apart of the z pass is very expensive. I just ommitied this and moved it as apart of the diffuse pass. pre-z/post-z should reject most geometry. 