### PR TITLE
feature: shadow cache

### DIFF
--- a/HPL2/include/graphics/IndexPool.h
+++ b/HPL2/include/graphics/IndexPool.h
@@ -14,12 +14,14 @@ namespace hpl {
         IndexPool(uint32_t reserve);
 
         uint32_t requestId();
+        inline uint32_t reserve() {return m_reserve;}
         void returnId(uint32_t);
     private:
         struct IdRange {
             uint32_t m_start;
             uint32_t m_end;
         };
+        uint32_t m_reserve;
         folly::small_vector<IdRange, 256> m_avaliable;
     };
 

--- a/HPL2/include/graphics/RendererDeferred.h
+++ b/HPL2/include/graphics/RendererDeferred.h
@@ -20,6 +20,7 @@
 
 #include "engine/RTTI.h"
 
+#include "graphics/ShadowCache.h"
 #include "scene/Viewport.h"
 #include "scene/World.h"
 #include "windowing/NativeWindow.h"
@@ -708,5 +709,6 @@ namespace hpl {
         cRenderList m_reflectionRendererList;
         std::unique_ptr<renderer::PassHBAOPlus> m_hbaoPlusPipeline;
         std::shared_ptr<DebugDraw> m_debug;
+        ShadowCache m_shadowCache;
     };
 }; // namespace hpl

--- a/HPL2/include/graphics/RendererDeferred.h
+++ b/HPL2/include/graphics/RendererDeferred.h
@@ -597,6 +597,7 @@ namespace hpl {
         std::array<std::array<LightResourceEntry, MaxLightUniforms>, ForgeRenderer::SwapChainLength> m_lightResources{};
         // z pass
         SharedShader m_zPassShader;
+        SharedShader m_zPassShadowShader;
         SharedPipeline m_zPassPipelineCCW;
         SharedPipeline m_zPassPipelineCW;
 

--- a/HPL2/include/graphics/ShadowCache.h
+++ b/HPL2/include/graphics/ShadowCache.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "graphics/IndexPool.h"
+#include <cstdint>
+#include <vector>
+
+#include <folly/small_vector.h>
+
+#include <Common_3/Graphics/Interfaces/IGraphics.h>
+#include <Common_3/Utilities/RingBuffer.h>
+#include <FixPreprocessor.h>
+
+
+namespace hpl {
+    class ShadowCache {
+    public:
+
+        struct ShadowGroup {
+        public:
+            static constexpr uint8_t IsLeaf = 0x1;
+            static constexpr uint8_t HasLeafs = 0x2;
+            static constexpr uint8_t HasGroups = 0x4;
+
+            uint16_t m_idx;
+
+            uint16_t m_x;
+            uint16_t m_y;
+            uint32_t m_age;
+
+            uint16_t m_parent; // the parent of the cache entry
+            uint16_t m_child; // the start of the group
+
+            // linked list for all cut levels at the same cut
+            uint16_t m_next;
+            uint16_t m_prev;
+
+            uint8_t m_flags;
+            uint8_t m_occupyMask: 4; // mask for the entires occuped
+            uint8_t m_slot: 4; // the slot index
+            uint8_t m_level;
+
+            uint16_t m_hashes[4];
+        };
+
+
+        struct CutLevel {
+            uint16_t m_begin = UINT16_MAX;
+        };
+
+        ShadowCache(uint32_t width, uint32_t height, uint32_t hDivisions, uint32_t vDivision, uint8_t maxCuts);
+        void reset(uint32_t age);
+        uint4 find(uint16_t hash, uint8_t level, uint32_t age);
+    private:
+        ShadowGroup* allocGroup();
+        ShadowCache::ShadowGroup* createCut(ShadowGroup* group);
+
+        void freeGroup(ShadowGroup* group);
+        void freeChildren(ShadowGroup* group);
+
+        void updateAge(ShadowCache::ShadowGroup* current, uint32_t age);
+        void insertAfter(ShadowCache::ShadowGroup* current, ShadowCache::ShadowGroup* grp);
+        void insertBefore(ShadowCache::ShadowGroup* current, ShadowCache::ShadowGroup* grp);
+
+        uint2 m_quadSize;
+        hpl::IndexPool m_pool;
+        std::vector<ShadowGroup> m_alloc; // a reserved pool of entries will contain the max possible i.e all the quads are at its lowest cut
+        std::vector<CutLevel> m_cut; // cut levels for each quad
+    };
+}

--- a/HPL2/resource/ShaderList.fsl
+++ b/HPL2/resource/ShaderList.fsl
@@ -1,9 +1,17 @@
 /// Copyright © 2009-2020 Frictional Games
 /// Copyright 2023 Michael Pollind
 /// SPDX-License-Identifier: GPL-3.0
-
-#vert solid_z.vert
+#vert solid_z_shadow.vert
     #include "solid_z.vert.fsl"
+#end
+
+#frag solid_z_shadow.frag
+    #define ALPHA_REJECT 0.5
+    #include "solid_z_shadow.frag.fsl"
+#end
+
+#vert solid_z_shadow.vert
+    #include "solid_z_shadow.vert.fsl"
 #end
 
 #frag solid_z.frag

--- a/HPL2/resource/pbr.h.fsl
+++ b/HPL2/resource/pbr.h.fsl
@@ -1,0 +1,17 @@
+// https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
+//
+float3 F_Schlick (float3 f0 , float f90 , float u ){
+    return f0 + ( f90 - f0 ) * pow (1. f - u , 5. f ) ;
+}
+
+float Fr_DisneyDiffuse(float NdotV ,float NdotL ,float LdotH ,float linearRoughness)
+{
+    float energyBias = lerp (0 , 0.5 , linearRoughness ) ;
+    float energyFactor = lerp (1.0 , 1.0 / 1.51 , linearRoughness ) ;
+    float fd90 = energyBias + 2.0 * LdotH * LdotH * linearRoughness ;
+    float3 f0 = float3 (1.0 f , 1.0 f , 1.0 f ) ;
+    float lightScatter = F_Schlick ( f0 , fd90 , NdotL ) * r ;
+    float viewScatter = F_Schlick ( f0 , fd90 , NdotV ) * r ;
+
+    return lightScatter * viewScatter * energyFactor ;
+}

--- a/HPL2/resource/solid_diffuse.frag.fsl
+++ b/HPL2/resource/solid_diffuse.frag.fsl
@@ -43,8 +43,38 @@ PsOut PS_MAIN(PsIn In)
     }
 #endif
 
+    float diffuseAlpha;
+    if(HasAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        if(IsAlphaSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).r;
+        } else {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).a;
+        }
+    } else {
+        diffuseAlpha = 1.0;
+    }
+
+    const float dissolveAmount = Get(uniformObjectBuffer)[Get(objectId)].dissolveAmount;
+
+    if(dissolveAmount < 1.0 || HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig) || HasDissolveFilter(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        float2 vDissolveCoords = In.Position.xy * (1.0/128.0); //128 = size of dissolve texture.
+        float fDissolve = SampleTex2D(dissolveMap, Get(dissolveSampler), vDissolveCoords).x;
+        
+        if(HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            //Get in 0.75 - 1 range
+            fDissolve = fDissolve*0.25 + 0.75;
+
+            float fDissolveAlpha = SampleTex2D(Get(dissolveAlphaMap), Get(materialSampler), texCoord.xy).r;
+            fDissolve -= (0.25 - fDissolveAlpha * 0.25);
+        } else {
+            //Get in 0.5 - 1 range.
+            fDissolve = fDissolve*0.5 + 0.5;
+        }
+        diffuseAlpha = fDissolve -  (1.0 - (dissolveAmount * diffuseAlpha)) * 0.5;
+    }
+    
     float4 diffuseColor = SampleTex2D(Get(diffuseMap), Get(materialSampler), texCoord.xy);
-    if(diffuseColor.w < ALPHA_REJECT ) {
+    if(diffuseColor.w < ALPHA_REJECT || diffuseAlpha < ALPHA_REJECT) {
         discard;
     }
 

--- a/HPL2/resource/solid_z.frag.fsl
+++ b/HPL2/resource/solid_z.frag.fsl
@@ -8,67 +8,10 @@
 STRUCT(PsIn) 
 {
 	DATA(float4, Position, SV_Position);
-	DATA(float3, pos, POSITION);
-	DATA(float2, uv, TEXCOORD0);
-    DATA(float3, normal, NORMAL);
-    DATA(float3, tangent, TANGENT);
-    DATA(float3, bitangent, BITANGENT);
 };
 
 float4 PS_MAIN(PsIn In)
 {
     INIT_MAIN;
-    float2 texCoord = In.uv.xy;
-    uint materialID = Get(uniformObjectBuffer)[Get(objectId)].materialID;
-    
-    #ifdef PARALLAX_ENABLED
-        if(HasHeight(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-            texCoord.xy += ParallaxAdvance(texCoord,
-                0.0,
-                8.0, 
-                Get(uniformMaterialBuffer)[materialID].heightMapScale * PARALLAX_MULTIPLIER,
-                In.pos,
-                In.normal,
-                In.tangent,
-                In.bitangent,
-                IsHeightMapSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig));
-        }
-    #endif    
-    
-    float diffuseAlpha;
-    if(HasAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-        if(IsAlphaSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).r;
-        } else {
-            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).a;
-        }
-    } else {
-        diffuseAlpha = 1.0;
-    }
-
-    const float dissolveAmount = Get(uniformObjectBuffer)[Get(objectId)].dissolveAmount;
-
-    if(dissolveAmount < 1.0 || HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig) || HasDissolveFilter(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-        float2 vDissolveCoords = In.Position.xy * (1.0/128.0); //128 = size of dissolve texture.
-        float fDissolve = SampleTex2D(dissolveMap, Get(dissolveSampler), vDissolveCoords).x;
-        
-        if(HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
-            //Get in 0.75 - 1 range
-            fDissolve = fDissolve*0.25 + 0.75;
-
-            float fDissolveAlpha = SampleTex2D(Get(dissolveAlphaMap), Get(materialSampler), texCoord.xy).r;
-            fDissolve -= (0.25 - fDissolveAlpha * 0.25);
-        } else {
-            //Get in 0.5 - 1 range.
-            fDissolve = fDissolve*0.5 + 0.5;
-        }
-        diffuseAlpha = fDissolve -  (1.0 - (dissolveAmount * diffuseAlpha)) * 0.5;
-    }
-
-    
-    if(diffuseAlpha < ALPHA_REJECT) {
-        discard;
-    }
-
     RETURN(float4(0,0,0,0));
 }

--- a/HPL2/resource/solid_z.vert.fsl
+++ b/HPL2/resource/solid_z.vert.fsl
@@ -5,19 +5,11 @@
 STRUCT(VSInput)
 {
 	DATA(float3, Position, POSITION);
-   // DATA(float2, TexCoord, TEXCOORD0);
-   // DATA(float3, Normal, NORMAL);
-   // DATA(float3, Tangent, TANGENT);
 };
 
 STRUCT(VSOutput)
 {
 	DATA(float4, Position, SV_Position);
- //   DATA(float3, pos, POSITION);
- //   DATA(float2, uv, TEXCOORD0);
- //   DATA(float3, normal, NORMAL);
- //   DATA(float3, tangent, TANGENT);
- //   DATA(float3, bitangent, BITANGENT);
 };
 
 VSOutput VS_MAIN(VSInput In)
@@ -28,14 +20,7 @@ VSOutput VS_MAIN(VSInput In)
     float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
     float4x4 modelViewPrj = mul(Get(projMat), modelView);
     
-//    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
     Out.Position = mul(modelViewPrj , float4(In.Position.xyz, 1.0));
-  //  Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
-    
-  //  float3x3 normalMat = ToNormalMat(Get(uniformObjectBuffer)[Get(objectId)].invModelMat, Get(invViewMat));
-  //  Out.normal = normalize(mul(normalMat, In.Normal.xyz));
-  //  Out.tangent = normalize(mul(normalMat, In.Tangent.xyz));
-  //  Out.bitangent = normalize(mul(normalMat, cross(In.Tangent.xyz, In.Normal.xyz)));
 
     RETURN(Out);
 }

--- a/HPL2/resource/solid_z.vert.fsl
+++ b/HPL2/resource/solid_z.vert.fsl
@@ -5,19 +5,19 @@
 STRUCT(VSInput)
 {
 	DATA(float3, Position, POSITION);
-	DATA(float2, TexCoord, TEXCOORD0);
-	DATA(float3, Normal, NORMAL);
-	DATA(float3, Tangent, TANGENT);
+   // DATA(float2, TexCoord, TEXCOORD0);
+   // DATA(float3, Normal, NORMAL);
+   // DATA(float3, Tangent, TANGENT);
 };
 
 STRUCT(VSOutput)
 {
 	DATA(float4, Position, SV_Position);
-	DATA(float3, pos, POSITION);
-	DATA(float2, uv, TEXCOORD0);
-	DATA(float3, normal, NORMAL);
-	DATA(float3, tangent, TANGENT);
-	DATA(float3, bitangent, BITANGENT);
+ //   DATA(float3, pos, POSITION);
+ //   DATA(float2, uv, TEXCOORD0);
+ //   DATA(float3, normal, NORMAL);
+ //   DATA(float3, tangent, TANGENT);
+ //   DATA(float3, bitangent, BITANGENT);
 };
 
 VSOutput VS_MAIN(VSInput In)
@@ -28,14 +28,14 @@ VSOutput VS_MAIN(VSInput In)
     float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
     float4x4 modelViewPrj = mul(Get(projMat), modelView);
     
-    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
+//    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
     Out.Position = mul(modelViewPrj , float4(In.Position.xyz, 1.0));
-    Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
+  //  Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
     
-    float3x3 normalMat = ToNormalMat(Get(uniformObjectBuffer)[Get(objectId)].invModelMat, Get(invViewMat));
-    Out.normal = normalize(mul(normalMat, In.Normal.xyz));
-    Out.tangent = normalize(mul(normalMat, In.Tangent.xyz));
-    Out.bitangent = normalize(mul(normalMat, cross(In.Tangent.xyz, In.Normal.xyz)));
+  //  float3x3 normalMat = ToNormalMat(Get(uniformObjectBuffer)[Get(objectId)].invModelMat, Get(invViewMat));
+  //  Out.normal = normalize(mul(normalMat, In.Normal.xyz));
+  //  Out.tangent = normalize(mul(normalMat, In.Tangent.xyz));
+  //  Out.bitangent = normalize(mul(normalMat, cross(In.Tangent.xyz, In.Normal.xyz)));
 
     RETURN(Out);
 }

--- a/HPL2/resource/solid_z_cut.vert.fsl
+++ b/HPL2/resource/solid_z_cut.vert.fsl
@@ -1,0 +1,30 @@
+#define MATERIAL_SOLID 1
+#include "deferred_resources.h.fsl"
+#include "deferred_common.h.fsl"
+
+STRUCT(VSInput)
+{
+	DATA(float3, Position, POSITION);
+	DATA(float2, TexCoord, TEXCOORD0);
+};
+
+STRUCT(VSOutput)
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float3, pos, POSITION);
+	DATA(float2, uv, TEXCOORD0);
+};
+
+VSOutput VS_MAIN(VSInput In)
+{
+    INIT_MAIN;
+    VSOutput Out;
+    
+    float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
+    float4x4 modelViewPrj = mul(Get(projMat), modelView);
+    
+    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
+    Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
+
+    RETURN(Out);
+}

--- a/HPL2/resource/solid_z_shadow.frag.fsl
+++ b/HPL2/resource/solid_z_shadow.frag.fsl
@@ -1,0 +1,56 @@
+/// Copyright © 2009-2020 Frictional Games
+/// Copyright 2023 Michael Pollind
+/// SPDX-License-Identifier: GPL-3.0
+#define MATERIAL_SOLID 1
+#include "deferred_resources.h.fsl"
+#include "deferred_common.h.fsl"
+
+STRUCT(PsIn) 
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float3, pos, POSITION);
+	DATA(float2, uv, TEXCOORD0);
+};
+
+float4 PS_MAIN(PsIn In)
+{
+    INIT_MAIN;
+    float2 texCoord = In.uv.xy;
+    uint materialID = Get(uniformObjectBuffer)[Get(objectId)].materialID;
+    float diffuseAlpha;
+    if(HasAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        if(IsAlphaSingleChannel(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).r;
+        } else {
+            diffuseAlpha = SampleTex2D(Get(alphaMap), Get(materialSampler), texCoord.xy).a;
+        }
+    } else {
+        diffuseAlpha = 1.0;
+    }
+
+    const float dissolveAmount = Get(uniformObjectBuffer)[Get(objectId)].dissolveAmount;
+
+    if(dissolveAmount < 1.0 || HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig) || HasDissolveFilter(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+        float2 vDissolveCoords = In.Position.xy * (1.0/128.0); //128 = size of dissolve texture.
+        float fDissolve = SampleTex2D(dissolveMap, Get(dissolveSampler), vDissolveCoords).x;
+        
+        if(HasDissolveAlpha(Get(uniformMaterialBuffer)[materialID].materialConfig)) {
+            //Get in 0.75 - 1 range
+            fDissolve = fDissolve*0.25 + 0.75;
+
+            float fDissolveAlpha = SampleTex2D(Get(dissolveAlphaMap), Get(materialSampler), texCoord.xy).r;
+            fDissolve -= (0.25 - fDissolveAlpha * 0.25);
+        } else {
+            //Get in 0.5 - 1 range.
+            fDissolve = fDissolve*0.5 + 0.5;
+        }
+        diffuseAlpha = fDissolve -  (1.0 - (dissolveAmount * diffuseAlpha)) * 0.5;
+    }
+
+    
+    if(diffuseAlpha < ALPHA_REJECT) {
+        discard;
+    }
+
+    RETURN(float4(0,0,0,0));
+}

--- a/HPL2/resource/solid_z_shadow.vert.fsl
+++ b/HPL2/resource/solid_z_shadow.vert.fsl
@@ -12,6 +12,7 @@ STRUCT(VSOutput)
 {
 	DATA(float4, Position, SV_Position);
 	DATA(float3, pos, POSITION);
+	DATA(float2, uv, TEXCOORD0);
 };
 
 VSOutput VS_MAIN(VSInput In)

--- a/HPL2/resource/solid_z_shadow.vert.fsl
+++ b/HPL2/resource/solid_z_shadow.vert.fsl
@@ -1,0 +1,28 @@
+#define MATERIAL_SOLID 1
+#include "deferred_resources.h.fsl"
+#include "deferred_common.h.fsl"
+
+STRUCT(VSInput)
+{
+	DATA(float3, Position, POSITION);
+	DATA(float2, TexCoord, TEXCOORD0);
+};
+
+STRUCT(VSOutput)
+{
+	DATA(float4, Position, SV_Position);
+	DATA(float3, pos, POSITION);
+};
+
+VSOutput VS_MAIN(VSInput In)
+{
+    INIT_MAIN;
+    VSOutput Out;
+    
+    float4x4 modelView = mul(Get(viewMat), Get(uniformObjectBuffer)[Get(objectId)].modelMat);
+    float4x4 modelViewPrj = mul(Get(projMat), modelView);
+    
+    Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
+    Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
+    RETURN(Out);
+}

--- a/HPL2/resource/solid_z_shadow.vert.fsl
+++ b/HPL2/resource/solid_z_shadow.vert.fsl
@@ -24,6 +24,7 @@ VSOutput VS_MAIN(VSInput In)
     float4x4 modelViewPrj = mul(Get(projMat), modelView);
     
     Out.uv = mul(Get(uniformObjectBuffer)[Get(objectId)].uvMat, float4(In.TexCoord, 0, 1.0)).xy;
+    Out.Position = mul(modelViewPrj, float4(In.Position.xyz, 1.0));
     Out.pos = mul(modelView, float4(In.Position.xyz, 1.0)).xyz;
     RETURN(Out);
 }

--- a/HPL2/sources/graphics/IndexPool.cpp
+++ b/HPL2/sources/graphics/IndexPool.cpp
@@ -7,7 +7,8 @@
 
 namespace hpl {
 
-    IndexPool::IndexPool(uint32_t reserve) {
+    IndexPool::IndexPool(uint32_t reserve):
+        m_reserve(reserve) {
         m_avaliable.push_back({0, reserve - 1});
     }
 

--- a/HPL2/sources/graphics/RendererDeferred.cpp
+++ b/HPL2/sources/graphics/RendererDeferred.cpp
@@ -508,7 +508,8 @@ namespace hpl {
 
     cRendererDeferred::cRendererDeferred(cGraphics* apGraphics, cResources* apResources, std::shared_ptr<DebugDraw> debug)
         : iRenderer("Deferred", apGraphics, apResources)
-        , m_debug(debug) {
+        , m_debug(debug)
+        , m_shadowCache(8192, 4096, 8, 4, 3) {
         m_hbaoPlusPipeline = std::make_unique<renderer::PassHBAOPlus>();
         ////////////////////////////////////
         // Set up render specific things

--- a/HPL2/sources/graphics/ShadowCache.cpp
+++ b/HPL2/sources/graphics/ShadowCache.cpp
@@ -1,0 +1,192 @@
+#include "graphics/ShadowCache.h"
+#include "graphics/IndexPool.h"
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+namespace hpl {
+
+    void ShadowCache::insertAfter(ShadowCache::ShadowGroup* current, ShadowCache::ShadowGroup* grp) {
+        ASSERT(current);
+        ASSERT(grp);
+        uint16_t nextIdx = current->m_next;
+
+        current->m_next = grp->m_idx;
+        grp->m_prev = current->m_idx;
+
+        grp->m_next = nextIdx;
+        if(nextIdx != UINT16_MAX) {
+            m_alloc[nextIdx].m_prev = grp->m_idx;
+        }
+    }
+    void ShadowCache::insertBefore(ShadowCache::ShadowGroup* current, ShadowCache::ShadowGroup* grp) {
+        ASSERT(current);
+        ASSERT(grp);
+        uint16_t prevIdx = current->m_prev;
+
+        current->m_prev = grp->m_idx;
+        grp->m_next = current->m_idx;
+
+        grp->m_prev = prevIdx;
+        if(prevIdx != UINT16_MAX) {
+            m_alloc[prevIdx].m_next = grp->m_idx;
+        }
+    }
+    ShadowCache::ShadowCache(uint32_t width, uint32_t height, uint32_t hDivisions, uint32_t vDivision, uint8_t maxCuts):
+        m_quadSize(width/vDivision, height/ hDivisions),
+        m_pool((std::pow(std::max(1, (static_cast<int>(maxCuts) - 2)), 4) + 1) * hDivisions * vDivision) {
+        ASSERT(m_pool.reserve() > std::numeric_limits<uint16_t>::max());
+        m_alloc.resize(m_pool.reserve());
+        m_cut.resize(maxCuts);
+        ShadowCache::ShadowGroup* previous = nullptr;
+        for(size_t x = 0; x < hDivisions; x++) {
+            for(size_t y = 0; y < vDivision; y++) {
+                ShadowCache::ShadowGroup* entry = allocGroup();
+                entry->m_x = m_quadSize.x * x;
+                entry->m_y = m_quadSize.y * y;
+                if(previous != nullptr) {
+                    insertAfter(previous, entry);
+                }
+                if(previous == nullptr) {
+                    m_cut[0].m_begin = entry->m_idx;
+                }
+                previous = entry;
+            }
+        }
+    }
+
+    ShadowCache::ShadowGroup* ShadowCache::createCut(ShadowGroup* group) {
+        ShadowGroup* child = allocGroup();
+        child->m_parent = group->m_idx;
+        if (group->m_child == UINT16_MAX) {
+            group->m_child = child->m_idx;
+            child->m_parent = group->m_idx;
+        } else {
+            insertAfter(&m_alloc[group->m_child], child);
+        }
+        child->m_level = group->m_level + 1;
+        bool found = false;
+        for (uint8_t i = 0; i < 4; i++) {
+            if ((group->m_occupyMask & (1 << i)) == 0) {
+                group->m_occupyMask |= (1 << i); // we are going to set this entry is occupied
+                uint16_t x = (i % 2);
+                uint16_t y = (i / 2);
+                child->m_slot = i; // we assign the slot we occupy for this cut
+                uint2 quadSize = m_quadSize / (1 << child->m_level);
+                group->m_x = group->m_x + (x * quadSize.x);
+                group->m_y = group->m_y + (y * quadSize.y);
+                group->m_flags |= ShadowGroup::HasGroups;
+                found = true;
+                break;
+            }
+        }
+        ASSERT(found);
+        auto& nextCut = m_cut[child->m_level];
+        if (nextCut.m_begin == UINT16_MAX) {
+            nextCut.m_begin = child->m_idx;
+        } else {
+            insertBefore(&m_alloc[nextCut.m_begin], group);
+        }
+
+        return child;
+    }
+
+    uint4 ShadowCache::find(uint16_t hash, uint8_t level, uint32_t age) {
+        auto findGroupInCut = [&](ShadowGroup* group) {
+            ShadowGroup* result = nullptr;
+            for (uint16_t i = group->m_idx; i != UINT16_MAX; i = m_alloc[i].m_next) {
+                for(size_t k = 0; k < 4; k++) {
+                    // we found a matching hash
+                    if(m_alloc[i].m_hashes[k] == hash) {
+                        result = &m_alloc[i];
+                        goto exit;
+                    }
+                }
+                if (result == nullptr || m_alloc[i].m_age < result->m_age) {
+                    result = &m_alloc[i];
+                }
+            }
+        exit:
+            return result;
+        };
+        const uint8_t targetLevel = level == 0? 0: level - 1;
+        auto& targetCut = m_cut[targetLevel];
+
+        ShadowGroup* group = findGroupInCut(&m_alloc[targetCut.m_begin]);
+        if(level == 0) {
+            freeChildren(group);
+            group->m_flags |= ShadowGroup::IsLeaf;
+            group->m_hashes[0] = hash;
+            group->m_age = age;
+            return uint4(group->m_x, group->m_y, m_quadSize.x, m_quadSize.y);
+        } else {
+
+        }
+        return uint4(0,0,0,0);
+    }
+
+    ShadowCache::ShadowGroup* ShadowCache::allocGroup() {
+        uint32_t index = m_pool.requestId();
+        ShadowGroup* entry = &m_alloc[index];
+        std::memset(entry, 0, sizeof(ShadowGroup));
+        entry->m_parent = UINT16_MAX;
+        entry->m_child = UINT16_MAX;
+        entry->m_next = UINT16_MAX;
+        entry->m_prev = UINT16_MAX;
+        entry->m_idx = index;
+        return entry;
+    }
+
+    void ShadowCache::updateAge(ShadowCache::ShadowGroup* current, uint32_t age) {
+        for(uint16_t i = current->m_idx; i != UINT16_MAX; i = m_alloc[i].m_parent) {
+            if(age > current->m_age ) {
+               current->m_age = age;
+            }
+        }
+    }
+
+    void ShadowCache::freeChildren(ShadowCache::ShadowGroup* grp) {
+        if(grp->m_child != UINT16_MAX) {
+            for(uint32_t i = grp->m_child; i != UINT16_MAX && m_alloc[i].m_parent == grp->m_idx; i = m_alloc[i].m_next) {
+                m_alloc[i].m_parent = UINT16_MAX; // we invalidate the parent
+                freeGroup(&m_alloc[i]);
+            }
+        }
+        std::memset(grp->m_hashes, 0, sizeof(grp->m_hashes));
+        grp->m_occupyMask = 0;
+        grp->m_flags &= ~(ShadowGroup::HasLeafs | ShadowGroup::HasGroups);
+    }
+    void ShadowCache::freeGroup(ShadowCache::ShadowGroup* grp) {
+        for(auto& cut: m_cut) {
+            if(cut.m_begin == grp->m_idx) {
+                cut.m_begin = grp->m_next; // we assign the next if UINT16_MAX then that is accepted the layer is now empty
+            }
+        }
+        if(grp->m_child != UINT16_MAX) {
+            for(uint32_t i = grp->m_child; i != UINT16_MAX && m_alloc[i].m_parent == grp->m_idx; i = m_alloc[i].m_next) {
+                m_alloc[i].m_parent = UINT16_MAX; // we invalidate the parent
+                freeGroup(&m_alloc[i]);
+            }
+        }
+        if(grp->m_parent != UINT16_MAX) {
+            auto* parent = &m_alloc[grp->m_parent];
+            parent->m_occupyMask &= ~(1 << grp->m_slot); // we clear the occupy slot
+            if(parent->m_child == grp->m_idx) {
+                // if the next child has a mismatched index we've exausted cuts
+                if(grp->m_next != UINT16_MAX && m_alloc[grp->m_next].m_parent == parent->m_idx) {
+                    parent->m_child = grp->m_next;
+                }
+
+            }
+        }
+        if(grp->m_prev != UINT16_MAX && grp->m_next != UINT16_MAX) {
+            m_alloc[grp->m_prev].m_next = m_alloc[grp->m_next].m_idx;
+            m_alloc[grp->m_next].m_prev = m_alloc[grp->m_prev].m_idx;
+        } else if(grp->m_prev != UINT16_MAX) {
+            m_alloc[grp->m_prev].m_next = UINT16_MAX;
+        } else if(grp->m_next != UINT16_MAX) {
+            m_alloc[grp->m_next].m_prev = UINT16_MAX;
+        }
+        m_pool.returnId(grp->m_idx);
+    }
+}


### PR DESCRIPTION
this is a rough implementation of a shadow cache. shadows will be stored in a single large texture and bound once to the pipeline. the plan is to also pull in part of the forward+ to run the point-lights in a single pass. rendering spheres tends to produce lots and lots of overdraw. 

this is generally accepted as the more optimal solution. 
https://wickedengine.net/2018/01/10/optimizing-tile-based-light-culling/